### PR TITLE
Change create_index prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You can check out [the API documentation](https://docs.meilisearch.com/reference
 # Create an index
 client.create_index('books')
 # Create an index and give the primary-key
-client.create_index(uid: 'books', primaryKey: 'book_id')
+client.create_index('books', primaryKey: 'book_id')
 ```
 
 #### List all indexes <!-- omit in toc -->

--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -15,15 +15,10 @@ module MeiliSearch
     end
 
     # Usage:
-    # create_index('indexUID')
-    # create_index(uid: 'indexUID')
-    # create_index(uid: 'indexUID', primaryKey: 'id')
-    def create_index(attributes)
-      body = if attributes.is_a?(Hash)
-               attributes
-             else
-               { uid: attributes }
-             end
+    # client.create_index('indexUID')
+    # client.create_index('indexUID', primaryKey: 'id')
+    def create_index(index_uid, options = {})
+      body = { uid: index_uid }.merge(options)
       res = http_post '/indexes', body
       index_object(res['uid'])
     end
@@ -33,13 +28,11 @@ module MeiliSearch
     end
 
     # Usage:
-    # index('indexUID')
-    # index(uid: 'indexUID')
-    def index(attribute)
-      uid = attribute.is_a?(Hash) ? attribute[:uid] : attribute
-      raise IndexUidError if uid.nil?
+    # client.index('indexUID')
+    def index(index_uid)
+      raise IndexUidError if index_uid.nil?
 
-      index_object(uid)
+      index_object(index_uid)
     end
     alias get_index index
 

--- a/spec/meilisearch/client/indexes_spec.rb
+++ b/spec/meilisearch/client/indexes_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     clear_all_indexes(@client)
     @uid1 = 'uid1'
     @uid2 = 'uid2'
-    @uid3 = 'uid3'
     @primary_key = 'objectId'
   end
 
@@ -17,17 +16,10 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     expect(index.primary_key).to be_nil
   end
 
-  it 'creates an index without primary-key as an Hash' do
-    index = @client.create_index(uid: @uid2)
+  it 'creates an index with primary-key' do
+    index = @client.create_index(@uid2, primaryKey: @primary_key)
     expect(index).to be_a(MeiliSearch::Index)
     expect(index.uid).to eq(@uid2)
-    expect(index.primary_key).to be_nil
-  end
-
-  it 'creates an index with primary-key' do
-    index = @client.create_index(uid: @uid3, primaryKey: @primary_key)
-    expect(index).to be_a(MeiliSearch::Index)
-    expect(index.uid).to eq(@uid3)
     expect(index.primary_key).to eq(@primary_key)
   end
 
@@ -46,22 +38,22 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
   it 'gets list of indexes' do
     response = @client.indexes
     expect(response).to be_a(Array)
-    expect(response.count).to eq(3)
+    expect(response.count).to eq(2)
     uids = response.map { |elem| elem['uid'] }
-    expect(uids).to contain_exactly(@uid1, @uid2, @uid3)
+    expect(uids).to contain_exactly(@uid1, @uid2)
   end
 
   it 'shows a specific index' do
-    response = @client.show_index(@uid3)
+    response = @client.show_index(@uid2)
     expect(response).to be_a(Hash)
-    expect(response['uid']).to eq(@uid3)
+    expect(response['uid']).to eq(@uid2)
     expect(response['primaryKey']).to eq(@primary_key)
   end
 
   it 'returns an index object based on uid' do
-    index = @client.index(@uid3)
+    index = @client.index(@uid2)
     expect(index).to be_a(MeiliSearch::Index)
-    expect(index.uid).to eq(@uid3)
+    expect(index.uid).to eq(@uid2)
     expect(index.primary_key).to eq(@primary_key)
   end
 
@@ -70,8 +62,6 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     expect { @client.show_index(@uid1) }.to raise_meilisearch_http_error_with(404)
     expect(@client.delete_index(@uid2)).to be_nil
     expect { @client.show_index(@uid2) }.to raise_meilisearch_http_error_with(404)
-    expect(@client.delete_index(@uid3)).to be_nil
-    expect { @client.show_index(@uid3) }.to raise_meilisearch_http_error_with(404)
     expect(@client.indexes.count).to eq(0)
   end
 

--- a/spec/meilisearch/index/base_spec.rb
+++ b/spec/meilisearch/index/base_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MeiliSearch::Index do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index1 = client.create_index(@uid1)
-    @index2 = client.create_index(uid: @uid2, primaryKey: @primary_key)
+    @index2 = client.create_index(@uid2, primaryKey: @primary_key)
   end
 
   it 'shows the index' do

--- a/spec/meilisearch/index/settings_spec.rb
+++ b/spec/meilisearch/index/settings_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
   context 'Index with primary-key' do
     before(:all) do
       @uid = SecureRandom.hex(4)
-      @client.create_index(uid: @uid, primaryKey: 'id')
+      @client.create_index(@uid, primaryKey: 'id')
     end
 
     after(:all) { clear_all_indexes(@client) }

--- a/spec/meilisearch/index/updates_spec.rb
+++ b/spec/meilisearch/index/updates_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'MeiliSearch::Index - Updates' do
     ]
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
-    @index = client.create_index(uid: 'books', primaryKey: 'objectId')
+    @index = client.create_index('books', primaryKey: 'objectId')
   end
 
   after(:all) do


### PR DESCRIPTION
Related to [this comment](https://github.com/meilisearch/integration-guides/issues/2#issuecomment-642012475).

Before:

```ruby
client.create_index('indexUID')
client.create_index(uid: 'indexUID', primaryKey: 'books_id')
```

(In the second line, the `{}` are not mandatory, but it's an "object" = hash table in ruby)

After:

```ruby
client.create_index('indexUID')
client.create_index('indexUID', primaryKey: 'books_id')
```

Plus, I made the `index` (= `get_index`) method consistent with `create_index`.