### PR TITLE
Revert "Update release-drafter to skip PR with 'dependencies' label"

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -2,7 +2,6 @@ name-template: 'v$RESOLVED_VERSION 💎'
 tag-template: 'v$RESOLVED_VERSION'
 exclude-labels:
   - 'skip-changelog'
-  - 'dependencies'
 version-resolver:
   minor:
     labels:


### PR DESCRIPTION
Reverts meilisearch/meilisearch-ruby#55