### PR TITLE
Seach route: use POST instead of GET and add tests for placeholder

### DIFF
--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -81,16 +81,8 @@ module MeiliSearch
     ### SEARCH
 
     def search(query, options = {})
-      parsed_options = options.transform_keys(&:to_sym).map do |k, v|
-        if [:facetFilters, :facetsDistribution].include?(k)
-          [k, v.inspect]
-        elsif v.is_a?(Array)
-          [k, v.join(',')]
-        else
-          [k, v]
-        end
-      end.to_h
-      http_get "/indexes/#{@uid}/search", { q: query }.merge(parsed_options)
+      parsed_options = options.compact
+      http_post "/indexes/#{@uid}/search", { q: query }.merge(parsed_options)
     end
 
     ### UPDATES


### PR DESCRIPTION
- [x] Closes #71 
- [x] Add tests for placeholder

<s>⚠️ Depending on this issue https://github.com/meilisearch/MeiliSearch/issues/866:
- the way of managing the search method can be changed
- the `breaking-change` label could be removed</s>

⚠️ should be merged
- when the v0.13.0 of MS is released
- this PR #78 is merged