### PR TITLE
feat: add ability to set bigger timeout and max_retries option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [🚀 Getting started](#-getting-started)
 - [🤖 Compatibility with MeiliSearch](#-compatibility-with-meilisearch)
 - [🎬 Examples](#-examples)
+  - [Client](#client)
   - [Indexes](#indexes)
   - [Documents](#documents)
   - [Update status](#update-status)
@@ -116,6 +117,21 @@ This package is compatible with the following MeiliSearch versions:
 
 All HTTP routes of MeiliSearch are accessible via methods in this SDK.</br>
 You can check out [the API documentation](https://docs.meilisearch.com/references/).
+
+### Client
+
+```ruby
+# Default client
+client = MeiliSearch::Client.new('http://127.0.0.1:7700', 'masterKey')
+# Custom client
+client = MeiliSearch::Client.new('http://127.0.0.1:7700', 'masterKey', timeout: 2, max_retries: 2)
+```
+
+`timeout` - default value: `1` second<br>
+The time in seconds before a `Timeout::Error` is raised.
+
+`max_retries` - default value: `0`<br>
+If the HTTP request times out, this number of retries will be applied.
 
 ### Indexes
 

--- a/lib/meilisearch/http_request.rb
+++ b/lib/meilisearch/http_request.rb
@@ -69,7 +69,7 @@ module MeiliSearch
         query: query_params,
         body: body,
         timeout: @options[:timeout] || 1,
-        max_retries: @options[:max_retries] || 1
+        max_retries: @options[:max_retries] || 0
       }.compact
     end
 

--- a/lib/meilisearch/http_request.rb
+++ b/lib/meilisearch/http_request.rb
@@ -7,9 +7,10 @@ module MeiliSearch
   class HTTPRequest
     include HTTParty
 
-    def initialize(url, api_key = nil)
+    def initialize(url, api_key = nil, options = {})
       @base_url = url
       @api_key = api_key
+      @options = options
       @headers = {
         'Content-Type' => 'application/json',
         'X-Meili-API-Key' => api_key
@@ -67,7 +68,8 @@ module MeiliSearch
         headers: @headers,
         query: query_params,
         body: body,
-        timeout: 1
+        timeout: @options[:timeout] || 1,
+        max_retries: @options[:max_retries] || 1
       }.compact
     end
 

--- a/spec/meilisearch_spec.rb
+++ b/spec/meilisearch_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe MeiliSearch do
       client.indexes
     end.to raise_error(MeiliSearch::CommunicationError)
   end
+
+  it 'allows to set a custom timeout and max_retries' do
+    client = MeiliSearch::Client.new($URL, $MASTER_KEY, timeout: 0, max_retries: 2)
+    expect do
+      client.indexes
+    end.to raise_error(Timeout::Error)
+  end
 end


### PR DESCRIPTION
In version 0.17.1 httparty introduces support for max_retries
option. Since this gem already depends on httparty >= 0.17.1,
I think it is safe to add support for this feature without any other
conditions. In order to keep backward compatibility, default value
for `max_retries` options is set to 1, which means that retries are
disabled by default.

Added ability to configure request timeout. Default version for this
options stays same and equals 1 second. User can set bigger or smaller
timeout.

Closes #87 