### PR TITLE
Changes about the MeiliSearch's next release (v0.16.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -166,8 +166,6 @@ get_indexes_stats_1: |-
   client.stats
 get_health_1: |-
   client.health
-update_health_1: |-
-  client.update_health(false)
 get_version_1: |-
   client.version
 distinct_attribute_guide_1: |-
@@ -195,8 +193,8 @@ field_properties_guide_displayed_1: |-
 filtering_guide_1: |-
   index.search('Avengers', { filters: 'release_date > 795484800' })
 filtering_guide_2: |-
-  index.search('Batman', { 
-    filters: 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")' 
+  index.search('Batman', {
+    filters: 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")'
   })
 filtering_guide_3: |-
   index.search('horror', { filters: 'director = "Jordan Peele"' })
@@ -207,11 +205,11 @@ filtering_guide_4: |-
 search_parameter_guide_query_1: |-
   index.search('shifu')
 search_parameter_guide_offset_1: |-
-  index.search('shifu', { 
+  index.search('shifu', {
     offset: 1
   })
 search_parameter_guide_limit_1: |-
-  index.search('shifu', { 
+  index.search('shifu', {
     limit: 2
   })
 search_parameter_guide_retrieve_1: |-

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ JSON output:
 
 ## 🤖 Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
 
 ## 💡 Learn More
 

--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -63,10 +63,6 @@ module MeiliSearch
       http_get '/health'
     end
 
-    def update_health(bool)
-      http_put '/health', health: bool
-    end
-
     ### STATS
 
     def version

--- a/spec/meilisearch/client/health_spec.rb
+++ b/spec/meilisearch/client/health_spec.rb
@@ -12,9 +12,4 @@ RSpec.describe 'MeiliSearch::Client - Health' do
     expect(wrong_client.healthy?).to be false
   end
 
-  it 'sets unhealthy' do
-    client.update_health(false)
-    expect(client.healthy?).to be false
-    client.update_health(true)
-  end
 end

--- a/spec/meilisearch/client/health_spec.rb
+++ b/spec/meilisearch/client/health_spec.rb
@@ -11,5 +11,4 @@ RSpec.describe 'MeiliSearch::Client - Health' do
   it 'is unhealthy when the url is invalid' do
     expect(wrong_client.healthy?).to be false
   end
-
 end


### PR DESCRIPTION
Related to this issue: https://github.com/meilisearch/integration-guides/issues/52

- [x] Update README
- [x] Remove `update_health` method 

This PR:
- gathers the changes related to the next release of MeiliSearch (v0.16.0) so that this package is ready when the official release is out.
- should pass the tests against the [latest prerelease of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases). This should be tested locally.
- might eventually fail until the MeiliSearch v0.16.0 is out.

⚠️ This PR should NOT be merged until the MeiliSearch's next release (v0.16.0) is out.