### PR TITLE
Introduce idiomatic setters

### DIFF
--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -140,6 +140,7 @@ module MeiliSearch
     def update_settings(settings)
       http_post "/indexes/#{@uid}/settings", settings
     end
+    alias settings= update_settings
 
     def reset_settings
       http_delete "/indexes/#{@uid}/settings"
@@ -155,6 +156,7 @@ module MeiliSearch
     def update_ranking_rules(ranking_rules)
       http_post "/indexes/#{@uid}/settings/ranking-rules", ranking_rules
     end
+    alias ranking_rules= update_ranking_rules
 
     def reset_ranking_rules
       http_delete "/indexes/#{@uid}/settings/ranking-rules"
@@ -170,6 +172,7 @@ module MeiliSearch
     def update_synonyms(synonyms)
       http_post "/indexes/#{@uid}/settings/synonyms", synonyms
     end
+    alias synonyms= update_synonyms
 
     def reset_synonyms
       http_delete "/indexes/#{@uid}/settings/synonyms"
@@ -186,6 +189,7 @@ module MeiliSearch
       body = stop_words.is_a?(Array) ? stop_words : [stop_words]
       http_post "/indexes/#{@uid}/settings/stop-words", body
     end
+    alias stop_words= update_stop_words
 
     def reset_stop_words
       http_delete "/indexes/#{@uid}/settings/stop-words"
@@ -201,6 +205,7 @@ module MeiliSearch
     def update_distinct_attribute(distinct_attribute)
       http_post "/indexes/#{@uid}/settings/distinct-attribute", distinct_attribute
     end
+    alias distinct_attribute= update_distinct_attribute
 
     def reset_distinct_attribute
       http_delete "/indexes/#{@uid}/settings/distinct-attribute"
@@ -216,6 +221,7 @@ module MeiliSearch
     def update_searchable_attributes(searchable_attributes)
       http_post "/indexes/#{@uid}/settings/searchable-attributes", searchable_attributes
     end
+    alias searchable_attributes= update_searchable_attributes
 
     def reset_searchable_attributes
       http_delete "/indexes/#{@uid}/settings/searchable-attributes"
@@ -231,6 +237,7 @@ module MeiliSearch
     def update_displayed_attributes(displayed_attributes)
       http_post "/indexes/#{@uid}/settings/displayed-attributes", displayed_attributes
     end
+    alias displayed_attributes= update_displayed_attributes
 
     def reset_displayed_attributes
       http_delete "/indexes/#{@uid}/settings/displayed-attributes"
@@ -246,6 +253,7 @@ module MeiliSearch
     def update_attributes_for_faceting(attributes_for_faceting)
       http_post "/indexes/#{@uid}/settings/attributes-for-faceting", attributes_for_faceting
     end
+    alias attributes_for_faceting= update_attributes_for_faceting
 
     def reset_attributes_for_faceting
       http_delete "/indexes/#{@uid}/settings/attributes-for-faceting"


### PR DESCRIPTION
This introduces idiomatic setters.

### Summary of the new aliases

Instead of writing e.g.

```ruby
index.update_distinct_attribute 'my_attribute'
```

you can now also write

```ruby
index.distinct_attribute = 'my_attribute'
```


### (No) setter for documents

I additionally considered `documents=` but decided against it because it's adding and replacing and not deleting all and then adding the new ones.


### Is setting to nil always resetting?

I considered additionally allowing setting to `nil` for resetting because (at for least `distinct_attribute`) setting to nil raises an error and this might be an adequate usage:

```ruby
index.distinct_attribute = nil
MeiliSearch::ApiError: 400 Bad Request - Invalid JSON: EOF while parsing a value at line 1 column 0. See https://docs.meilisearch.com/errors#bad_request.
from /Users/bb/.rvm/gems/ruby-2.6.6/gems/meilisearch-0.14.0/lib/meilisearch/http_request.rb:77:in `validate'
```
Instead of the error, reset_distinct_attribute could be invoked.

What do you think. Should we implement it? Any settings where this might not be a good idea?

### General thoughts on the API style

The Ruby API for index and client is full of aliases. I'm torn between having/keeping them (hey, I just added more 😉) and not liking them, especially the non-idiomatic `get_foo` ones because they fill up the code browser/introspection:

```ruby
$ rails c
Running via Spring preloader in process 4567
Loading development environment (Rails 6.0.3.4)
> client = MeiliSearch::Client.new('http://127.0.0.1:7700', 'masterKey')
=> #<MeiliSearch::Client:0x00007fb66cc6ff28 @api_key="masterKey", @base_url="http://127.0.0.1:7700", @headers={"Content-Type"=>"application/json", "X-Meili-API-Key"=>"masterKey"}, @options={}>
> index = client.index('my_index')
=> #<MeiliSearch::Index:0x00007fb66cd0d0e8 @api_key="masterKey", @base_url="http://127.0.0.1:7700", @headers={"Content-Type"=>"application/json", "X-Meili-API-Key"=>"masterKey"}, @options={}, @uid="posts">
> ls index
ActiveSupport::ToJsonWithActiveSupportEncoder#methods: to_json
ActiveSupport::Dependencies::ZeitwerkIntegration::RequireDependency#methods: require_dependency
MeiliSearch::HTTPRequest#methods: http_delete  http_get  http_post  http_put
MeiliSearch::Index#methods:
  add_documents              displayed_attributes         get_one_document           primary_key                    search                          update_displayed_attributes
  add_or_replace_documents   distinct_attribute           get_primary_key            ranking_rules                  searchable_attributes           update_distinct_attribute
  add_or_update_documents    document                     get_ranking_rules          replace_documents              settings                        update_documents
  attributes_for_faceting    documents                    get_searchable_attributes  reset_attributes_for_faceting  show                            update_index
  delete                     fields_distribution          get_settings               reset_displayed_attributes     show_index                      update_ranking_rules
  delete_all_documents       get_all_update_status        get_stop_words             reset_distinct_attribute       stats                           update_searchable_attributes
  delete_document            get_attributes_for_faceting  get_synonyms               reset_ranking_rules            stop_words                      update_settings
  delete_documents           get_displayed_attributes     get_update_status          reset_searchable_attributes    synonyms                        update_stop_words
  delete_index               get_distinct_attribute       indexing?                  reset_settings                 uid                             update_synonyms
  delete_multiple_documents  get_document                 last_update                reset_stop_words               update                          wait_for_pending_update
  delete_one_document        get_documents                number_of_documents        reset_synonyms                 update_attributes_for_faceting
instance variables: @api_key  @base_url  @headers  @options  @uid
>
```

Note: The `ls` command comes from [pry](https://github.com/pry/pry), see [pry's documentation on code browsing](https://github.com/pry/pry#code-browsing). If you just want to get the idea without digging deeper into pry, it can be partially replicated using e.g.

```ruby
> index.methods.sort - index.class.superclass.instance_methods
=> [:add_documents,
 :add_or_replace_documents,
 :add_or_update_documents,
 :attributes_for_faceting,
 :delete,
 :delete_all_documents,
...
```
