### PR TITLE
Changes due to implicit index creation introduction

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -4,7 +4,7 @@
 # You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
 ---
 get_one_index_1: |-
-  client.index('movies')
+  client.fetch_index('movies')
 list_all_indexes_1: |-
   client.indexes
 create_an_index_1: |-

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@
 
 # lock
 Gemfile.lock
+
+# VScode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ NB: you can also download MeiliSearch from **Homebrew** or **APT**.
 require 'meilisearch'
 
 client = MeiliSearch::Client.new('http://127.0.0.1:7700', 'masterKey')
-index = client.create_index('books') # If your index does not exist
-index = client.index('books')        # If you already created your index
+
+# An index is where the documents are stored.
+index = client.index('books')
 
 documents = [
   { book_id: 123,  title: 'Pride and Prejudice' },
@@ -85,6 +86,7 @@ documents = [
   { book_id: 4,    title: 'Harry Potter and the Half-Blood Prince' },
   { book_id: 42,   title: 'The Hitchhiker\'s Guide to the Galaxy' }
 ]
+# If the index 'movies' does not exist, MeiliSearch creates it when you first add the documents.
 index.add_documents(documents) # => { "updateId": 0 }
 ```
 

--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -24,6 +24,7 @@ module MeiliSearch
         index_instance = fetch_index(index_uid)
       rescue ApiError => e
         raise e unless e.code == 'index_not_found'
+
         index_instance = create_index(index_uid, options)
       end
       index_instance

--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -10,26 +10,23 @@ module MeiliSearch
       http_get '/indexes'
     end
 
-    def show_index(index_uid)
-      index_object(index_uid).show
-    end
-
     # Usage:
     # client.create_index('indexUID')
     # client.create_index('indexUID', primaryKey: 'id')
     def create_index(index_uid, options = {})
       body = options.merge(uid: index_uid)
-      res = http_post '/indexes', body
-      index_object(res['uid'])
+      index_hash = http_post '/indexes', body
+      index_object(index_hash['uid'], index_hash['primaryKey'])
     end
 
     def get_or_create_index(index_uid, options = {})
       begin
-        create_index(index_uid, options)
+        index_instance = fetch_index(index_uid)
       rescue ApiError => e
-        raise e unless e.code == 'index_already_exists'
+        raise e unless e.code == 'index_not_found'
+        index_instance = create_index(index_uid, options)
       end
-      index_object(index_uid)
+      index_instance
     end
 
     def delete_index(index_uid)
@@ -41,7 +38,10 @@ module MeiliSearch
     def index(index_uid)
       index_object(index_uid)
     end
-    alias get_index index
+
+    def fetch_index(index_uid)
+      index_object(index_uid).fetch_info
+    end
 
     ### KEYS
 
@@ -86,8 +86,8 @@ module MeiliSearch
 
     private
 
-    def index_object(uid)
-      Index.new(uid, @base_url, @api_key)
+    def index_object(uid, primary_key = nil)
+      Index.new(uid, @base_url, @api_key, primary_key)
     end
   end
 end

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -6,19 +6,24 @@ require 'timeout'
 module MeiliSearch
   class Index < HTTPRequest
     attr_reader :uid
+    attr_reader :primary_key
 
-    def initialize(index_uid, url, api_key = nil)
+    def initialize(index_uid, url, api_key = nil, primary_key = nil)
       @uid = index_uid
+      @primary_key = primary_key
       super(url, api_key)
     end
 
-    def show
-      http_get "/indexes/#{@uid}"
+    def fetch_info
+      index_hash = http_get "/indexes/#{@uid}"
+      @primary_key = index_hash['primaryKey']
+      self
     end
-    alias show_index show
 
     def update(body)
-      http_put "/indexes/#{@uid}", body
+      index_hash = http_put "/indexes/#{@uid}", body
+      @primary_key = index_hash['primaryKey']
+      self
     end
     alias update_index update
 
@@ -27,10 +32,10 @@ module MeiliSearch
     end
     alias delete_index delete
 
-    def primary_key
-      show['primaryKey']
+    def fetch_primary_key
+      fetch_info.primary_key
     end
-    alias get_primary_key primary_key
+    alias get_primary_key fetch_primary_key
 
     ### DOCUMENTS
 

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -5,8 +5,7 @@ require 'timeout'
 
 module MeiliSearch
   class Index < HTTPRequest
-    attr_reader :uid
-    attr_reader :primary_key
+    attr_reader :uid, :primary_key
 
     def initialize(index_uid, url, api_key = nil, primary_key = nil)
       @uid = index_uid

--- a/spec/meilisearch/client/indexes_spec.rb
+++ b/spec/meilisearch/client/indexes_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     expect(index).to be_a(MeiliSearch::Index)
     expect(index.uid).to eq(@uid1)
     expect(index.primary_key).to be_nil
+    expect(index.fetch_primary_key).to be_nil
   end
 
   it 'creates an index with primary-key' do
@@ -24,6 +25,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     expect(index).to be_a(MeiliSearch::Index)
     expect(index.uid).to eq(@uid2)
     expect(index.primary_key).to eq(@primary_key)
+    expect(index.fetch_primary_key).to eq(@primary_key)
   end
 
   it 'creates an index with uid in options - should not take it into account' do
@@ -31,31 +33,37 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     expect(index).to be_a(MeiliSearch::Index)
     expect(index.uid).to eq(@uid3)
     expect(index.primary_key).to eq(@primary_key)
+    expect(index.fetch_primary_key).to eq(@primary_key)
   end
 
   it 'creates an new index with get_or_create_index method' do
     index = @client.get_or_create_index(@uid4)
+    expect(index).to be_a(MeiliSearch::Index)
     expect(@client.indexes.count).to eq(4)
-    expect(@client.index(@uid4).uid).to eq(index.uid)
-    expect(@client.index(@uid4).uid).to eq(@uid4)
-    expect(@client.index(@uid4).primary_key).to be_nil
+    expect(@client.fetch_index(@uid4).uid).to eq(index.uid)
+    expect(@client.fetch_index(@uid4).uid).to eq(@uid4)
+    expect(@client.fetch_index(@uid4).primary_key).to be_nil
+    expect(@client.fetch_index(@uid4).primary_key).to eq(index.primary_key)
   end
 
   it 'creates an new index with get_or_create_index method and a primary-key' do
     index = @client.get_or_create_index(@uid5, primaryKey: 'title')
+    expect(index).to be_a(MeiliSearch::Index)
     expect(@client.indexes.count).to eq(5)
-    expect(@client.index(@uid5).uid).to eq(index.uid)
-    expect(@client.index(@uid5).uid).to eq(@uid5)
-    expect(@client.index(@uid5).primary_key).to eq(index.primary_key)
-    expect(@client.index(@uid5).primary_key).to eq('title')
+    expect(@client.fetch_index(@uid5).uid).to eq(index.uid)
+    expect(@client.fetch_index(@uid5).uid).to eq(@uid5)
+    expect(@client.fetch_index(@uid5).primary_key).to eq(index.primary_key)
+    expect(@client.fetch_index(@uid5).primary_key).to eq('title')
   end
 
   it 'get an already existing index with get_or_create_index method' do
     index = @client.get_or_create_index(@uid5)
+    expect(index).to be_a(MeiliSearch::Index)
     expect(@client.indexes.count).to eq(5)
-    expect(@client.index(@uid5).uid).to eq(index.uid)
-    expect(@client.index(@uid5).uid).to eq(@uid5)
-    expect(@client.index(@uid5).primary_key).to eq('title')
+    expect(@client.fetch_index(@uid5).uid).to eq(index.uid)
+    expect(@client.fetch_index(@uid5).uid).to eq(@uid5)
+    expect(@client.fetch_index(@uid5).primary_key).to eq('title')
+    expect(@client.fetch_index(@uid5).primary_key).to eq(index.primary_key)
   end
 
   it 'fails to create an index with an uid already taken' do
@@ -78,35 +86,34 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     expect(uids).to contain_exactly(@uid1, @uid2, @uid3, @uid4, @uid5)
   end
 
-  it 'shows a specific index' do
-    response = @client.show_index(@uid2)
-    expect(response).to be_a(Hash)
-    expect(response['uid']).to eq(@uid2)
-    expect(response['primaryKey']).to eq(@primary_key)
+  it 'fetch a specific index' do
+    response = @client.fetch_index(@uid2)
+    expect(response).to be_a(MeiliSearch::Index)
+    expect(response.uid).to eq(@uid2)
+    expect(response.primary_key).to eq(@primary_key)
+    expect(response.fetch_primary_key).to eq(@primary_key)
   end
 
   it 'returns an index object based on uid' do
     index = @client.index(@uid2)
     expect(index).to be_a(MeiliSearch::Index)
     expect(index.uid).to eq(@uid2)
+    expect(index.primary_key).to be_nil
+    expect(index.fetch_primary_key).to eq(@primary_key)
     expect(index.primary_key).to eq(@primary_key)
   end
 
   it 'deletes index' do
     expect(@client.delete_index(@uid1)).to be_nil
-    expect { @client.show_index(@uid1) }.to raise_index_not_found_meilisearch_api_error
+    expect { @client.fetch_index(@uid1) }.to raise_index_not_found_meilisearch_api_error
     expect(@client.delete_index(@uid2)).to be_nil
-    expect { @client.show_index(@uid2) }.to raise_index_not_found_meilisearch_api_error
+    expect { @client.fetch_index(@uid2) }.to raise_index_not_found_meilisearch_api_error
     expect(@client.delete_index(@uid3)).to be_nil
-    expect { @client.show_index(@uid3) }.to raise_index_not_found_meilisearch_api_error
+    expect { @client.fetch_index(@uid3) }.to raise_index_not_found_meilisearch_api_error
     expect(@client.delete_index(@uid4)).to be_nil
-    expect { @client.show_index(@uid4) }.to raise_index_not_found_meilisearch_api_error
+    expect { @client.fetch_index(@uid4) }.to raise_index_not_found_meilisearch_api_error
     expect(@client.delete_index(@uid5)).to be_nil
-    expect { @client.show_index(@uid5) }.to raise_index_not_found_meilisearch_api_error
+    expect { @client.fetch_index(@uid5) }.to raise_index_not_found_meilisearch_api_error
     expect(@client.indexes.count).to eq(0)
-  end
-
-  it 'works with method aliases' do
-    expect(@client.method(:index) == @client.method(:get_index)).to be_truthy
   end
 end

--- a/spec/meilisearch/index/base_spec.rb
+++ b/spec/meilisearch/index/base_spec.rb
@@ -11,21 +11,21 @@ RSpec.describe MeiliSearch::Index do
     @index2 = client.create_index(@uid2, primaryKey: @primary_key)
   end
 
-  it 'shows the index' do
-    response = @index1.show
-    expect(response).to be_a(Hash)
-    expect(response['name']).to eq(@uid1)
-    expect(response['uid']).to eq(@uid1)
-    expect(response['uid']).to eq(@index1.uid)
-    expect(response['primaryKey']).to be_nil
+  it 'fetch the info of the index' do
+    index = @index1.fetch_info
+    expect(index).to be_a(MeiliSearch::Index)
+    expect(index.uid).to eq(@uid1)
+    expect(index.primary_key).to be_nil
   end
 
   it 'get primary-key of index if null' do
     expect(@index1.primary_key).to be_nil
+    expect(@index1.fetch_primary_key).to be_nil
   end
 
   it 'get primary-key of index if it exists' do
     expect(@index2.primary_key).to eq(@primary_key)
+    expect(@index2.fetch_primary_key).to eq(@primary_key)
   end
 
   it 'get uid of index' do
@@ -34,10 +34,11 @@ RSpec.describe MeiliSearch::Index do
 
   it 'updates primary-key of index if not defined before' do
     new_primary_key = 'id_test'
-    response = @index1.update(primaryKey: new_primary_key)
-    expect(response).to be_a(Hash)
-    expect(response['uid']).to eq(@uid1)
-    expect(@index1.primary_key).to eq(new_primary_key)
+    index = @index1.update(primaryKey: new_primary_key)
+    expect(index).to be_a(MeiliSearch::Index)
+    expect(index.uid).to eq(@uid1)
+    expect(index.primary_key).to eq(new_primary_key)
+    expect(index.fetch_primary_key).to eq(new_primary_key)
   end
 
   it 'returns error if trying to update primary-key if it is already defined' do
@@ -53,21 +54,20 @@ RSpec.describe MeiliSearch::Index do
 
   it 'deletes index' do
     expect(@index1.delete).to be_nil
-    expect { @index1.show }.to raise_index_not_found_meilisearch_api_error
+    expect { @index1.fetch_info }.to raise_index_not_found_meilisearch_api_error
     expect(@index2.delete).to be_nil
-    expect { @index2.show }.to raise_index_not_found_meilisearch_api_error
+    expect { @index2.fetch_info }.to raise_index_not_found_meilisearch_api_error
   end
 
   it 'fails to manipulate index object after deletion' do
-    expect { @index2.primary_key }.to raise_index_not_found_meilisearch_api_error
-    expect { @index2.show }.to raise_index_not_found_meilisearch_api_error
+    expect { @index2.fetch_primary_key }.to raise_index_not_found_meilisearch_api_error
+    expect { @index2.fetch_info }.to raise_index_not_found_meilisearch_api_error
     expect { @index2.update(primaryKey: 'id_test') }.to raise_index_not_found_meilisearch_api_error
     expect { @index2.delete }.to raise_index_not_found_meilisearch_api_error
   end
 
   it 'works with method aliases' do
-    expect(@index1.method(:show) == @index1.method(:show_index)).to be_truthy
-    expect(@index1.method(:primary_key) == @index1.method(:get_primary_key)).to be_truthy
+    expect(@index1.method(:fetch_primary_key) == @index1.method(:get_primary_key)).to be_truthy
     expect(@index1.method(:update) == @index1.method(:update_index)).to be_truthy
     expect(@index1.method(:delete) == @index1.method(:delete_index)).to be_truthy
   end

--- a/spec/meilisearch/index/documents_spec.rb
+++ b/spec/meilisearch/index/documents_spec.rb
@@ -41,7 +41,16 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
     end
 
     it 'infers primary-key attribute' do
-      expect(index.show['primaryKey']).to eq('objectId')
+      expect(index.fetch_primary_key).to eq('objectId')
+    end
+
+    it 'create the index during document addition' do
+      response = @client.index('newIndex').add_documents(documents)
+      expect(response).to be_a(Hash)
+      expect(response).to have_key('updateId')
+      sleep(0.2)
+      expect(@client.index('newIndex').fetch_primary_key).to eq('objectId')
+      expect(@client.index('newIndex').documents.count).to eq(documents.count)
     end
 
     it 'gets one document from its primary-key' do
@@ -247,7 +256,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       sleep(0.2)
-      expect(index.show['primaryKey']).to eq('unique')
+      expect(index.fetch_primary_key).to eq('unique')
     end
 
     it 'does not take into account the new primary key' do
@@ -259,7 +268,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       sleep(0.2)
-      expect(index.show['primaryKey']).to eq('unique')
+      expect(index.fetch_primary_key).to eq('unique')
       doc = index.document(3)
       expect(doc['unique']).to eq(3)
       expect(doc['id']).to eq(1)
@@ -285,7 +294,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       sleep(0.2)
-      expect(index.show['primaryKey']).to eq('objectId')
+      expect(index.fetch_primary_key).to eq('objectId')
       expect(index.get_update_status(response['updateId'])['status']).to eq('failed')
     end
 
@@ -294,7 +303,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       sleep(0.2)
-      expect(index.show['primaryKey']).to eq('objectId')
+      expect(index.fetch_primary_key).to eq('objectId')
       expect(index.get_update_status(response['updateId'])['status']).to eq('processed')
       expect(index.documents.count).to eq(1)
     end
@@ -304,7 +313,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       sleep(0.2)
-      expect(index.show['primaryKey']).to eq('objectId')
+      expect(index.fetch_primary_key).to eq('objectId')
       expect(index.get_update_status(response['updateId'])['status']).to eq('failed')
     end
   end
@@ -327,7 +336,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       sleep(0.2)
-      expect(index.show['primaryKey']).to eq('title')
+      expect(index.fetch_primary_key).to eq('title')
       expect(index.get_update_status(response['updateId'])['status']).to eq('failed')
       expect(index.documents.count).to eq(0)
     end
@@ -371,7 +380,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       sleep(0.2)
-      expect(index.show['primaryKey']).to eq('unique')
+      expect(index.fetch_primary_key).to eq('unique')
       expect(index.documents.count).to eq(1)
     end
   end


### PR DESCRIPTION
Related to https://github.com/meilisearch/integration-guides/issues/48

Changes:
- code samples are updated
- Getting Started is updated

Breaking changes:
- `get_or_create_index` now does at least one HTTP call (and two sometimes)
- a readable attribute was added to the `Index` class: `primary_key`. It is updated when updating/creating/fetching the index. If you directly want to fetch the upstream primary-key, use `index.fetch_primary_key` that will do an HTTP call. `index.primary_key` is now a simple getter and will not do any HTTP call.
- `index.show` and `client.show_index(...)` were removed. There are replaced by `index.fetch_info` and `client.fetch_index(...)`. There is no `client.get_index(...)` method because `get_XXX` are not idiomatic in ruby.
- `index.update` now returns an `Index` object
