### PR TITLE
Integrate wait_for_pending_update in test suite

### DIFF
--- a/spec/meilisearch/index/documents_spec.rb
+++ b/spec/meilisearch/index/documents_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       expect(response).to have_key('updateId')
       expect(index.documents.count).to eq(documents.count + 1)
       expect(index.document(id)['title']).to eq(title)
-      index.delete_document(id)
+      response = index.delete_document(id)
       index.wait_for_pending_update(response['updateId'])
     end
 

--- a/spec/meilisearch/index/documents_spec.rb
+++ b/spec/meilisearch/index/documents_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       response = index.add_documents(documents)
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.2)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.documents.count).to eq(documents.count)
     end
 
@@ -45,10 +45,11 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
     end
 
     it 'create the index during document addition' do
-      response = @client.index('newIndex').add_documents(documents)
+      new_index = @client.index('newIndex')
+      response = new_index.add_documents(documents)
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.2)
+      new_index.wait_for_pending_update(response['updateId'])
       expect(@client.index('newIndex').fetch_primary_key).to eq('objectId')
       expect(@client.index('newIndex').documents.count).to eq(documents.count)
     end
@@ -88,7 +89,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       response = index.update_documents(updated_documents)
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       doc1 = index.document(id1)
       doc2 = index.document(id2)
       expect(index.documents.count).to eq(documents.count)
@@ -102,7 +103,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       id = 123
       updated_document = { objectId: id, title: 'Emma' }
       response = index.update_documents(updated_document)
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       expect(index.documents.count).to eq(documents.count)
@@ -116,20 +117,20 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       title = 'Hamlet'
       new_doc = { objectId: id, title: title }
       response = index.add_documents(new_doc)
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       expect(index.documents.count).to eq(documents.count + 1)
       expect(index.document(id)['title']).to eq(title)
       index.delete_document(id)
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
     end
 
     it 'update a document with new fields' do
       id = 2
       doc = { objectId: id, note: '8/10' }
       response = index.update_documents(doc)
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       expect(index.documents.count).to eq(documents.count)
@@ -144,7 +145,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       response = index.replace_documents(objectId: id, title: 'Pride & Prejudice', note: '8.5/10')
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.documents.count).to eq(documents.count)
       doc = index.document(id)
       expect(doc['title']).to eq(new_title)
@@ -155,7 +156,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
     it 'deletes one document from index' do
       id = 456
       response = index.delete_document(id)
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       expect(index.documents.size).to eq(documents.count - 1)
@@ -165,7 +166,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
     it 'does nothing when trying to delete a document which does not exist' do
       id = 111
       response = index.delete_document(id)
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       expect(index.documents.size).to eq(documents.count - 1)
@@ -175,7 +176,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
     it 'deletes one document from index (with delete-batch route)' do
       id = 2
       response = index.delete_documents(id)
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       expect(index.documents.size).to eq(documents.count - 2)
@@ -185,7 +186,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
     it 'deletes one document from index (with delete-batch route as an array of one uid)' do
       id = 123
       response = index.delete_documents([id])
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       expect(index.documents.size).to eq(documents.count - 3)
@@ -195,7 +196,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
     it 'deletes multiples documents from index' do
       docs_to_delete = [1, 4]
       response = index.delete_documents(docs_to_delete)
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       expect(index.documents.size).to eq(documents.count - 3 - docs_to_delete.count)
@@ -203,7 +204,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
 
     it 'clears all documents from index' do
       response = index.delete_all_documents
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
       expect(index.documents).to be_empty
@@ -211,15 +212,15 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
     end
 
     it 'fails to add document with bad primary-key format' do
-      res = index.add_documents(objectId: 'toto et titi', title: 'Unknown')
-      sleep(0.1)
-      expect(index.get_update_status(res['updateId'])['status']).to eq('failed')
+      response = index.add_documents(objectId: 'toto et titi', title: 'Unknown')
+      index.wait_for_pending_update(response['updateId'])
+      expect(index.get_update_status(response['updateId'])['status']).to eq('failed')
     end
 
     it 'fails to add document with no primary-key' do
-      res = index.add_documents(id: 0, title: 'Unknown')
-      sleep(0.1)
-      expect(index.get_update_status(res['updateId'])['status']).to eq('failed')
+      response = index.add_documents(id: 0, title: 'Unknown')
+      index.wait_for_pending_update(response['updateId'])
+      expect(index.get_update_status(response['updateId'])['status']).to eq('failed')
     end
 
     it 'works with method aliases' do
@@ -255,7 +256,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       response = index.add_documents(documents, 'unique')
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.2)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.fetch_primary_key).to eq('unique')
     end
 
@@ -267,7 +268,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
                                         }, 'id')
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.2)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.fetch_primary_key).to eq('unique')
       doc = index.document(3)
       expect(doc['unique']).to eq(3)
@@ -293,7 +294,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       response = index.update_documents(documents, 'objectId')
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.2)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.fetch_primary_key).to be_nil
       expect(index.get_update_status(response['updateId'])['status']).to eq('failed')
     end
@@ -316,7 +317,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       response = index.add_documents(documents, 'title')
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.2)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.fetch_primary_key).to be_nil
       expect(index.get_update_status(response['updateId'])['status']).to eq('failed')
       expect(index.documents.count).to eq(0)
@@ -360,7 +361,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       response = index.add_documents(documents, 'unique')
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.2)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.fetch_primary_key).to eq('unique')
       expect(index.documents.count).to eq(1)
     end

--- a/spec/meilisearch/index/search/attributes_to_crop_spec.rb
+++ b/spec/meilisearch/index/search/attributes_to_crop_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe 'MeiliSearch::Index - Cropped search' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
-    sleep(0.1)
+    response = @index.add_documents(@documents)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do

--- a/spec/meilisearch/index/search/attributes_to_highlight.rb
+++ b/spec/meilisearch/index/search/attributes_to_highlight.rb
@@ -14,8 +14,8 @@ RSpec.describe 'MeiliSearch::Index - Search with highlight' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
-    sleep(0.1)
+    response = @index.add_documents(@documents)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do

--- a/spec/meilisearch/index/search/attributes_to_retrieve_spec.rb
+++ b/spec/meilisearch/index/search/attributes_to_retrieve_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'MeiliSearch::Index - Search with attributes to retrieve' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
-    sleep(0.1)
+    response = @index.add_documents(@documents)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do

--- a/spec/meilisearch/index/search/facet_filters_spec.rb
+++ b/spec/meilisearch/index/search/facet_filters_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe 'MeiliSearch::Index - Search with facetFilters' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
+    response = @index.add_documents(@documents)
     @index.update_attributes_for_faceting(['genre', 'year'])
-    sleep(0.1)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do

--- a/spec/meilisearch/index/search/facets_distribution_spec.rb
+++ b/spec/meilisearch/index/search/facets_distribution_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe 'MeiliSearch::Index - Search with facetsDistribution' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
+    response = @index.add_documents(@documents)
     @index.update_attributes_for_faceting(['genre', 'year', 'author'])
-    sleep(0.1)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do

--- a/spec/meilisearch/index/search/filters_spec.rb
+++ b/spec/meilisearch/index/search/filters_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe 'MeiliSearch::Index - Filtered search' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
-    sleep(0.1)
+    response = @index.add_documents(@documents)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do

--- a/spec/meilisearch/index/search/limit_spec.rb
+++ b/spec/meilisearch/index/search/limit_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'MeiliSearch::Index - Search with limit' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
-    sleep(0.1)
+    response = @index.add_documents(@documents)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do

--- a/spec/meilisearch/index/search/matches_spec.rb
+++ b/spec/meilisearch/index/search/matches_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'MeiliSearch::Index - Search with matches' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
-    sleep(0.1)
+    response = @index.add_documents(@documents)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do

--- a/spec/meilisearch/index/search/multi_params_spec.rb
+++ b/spec/meilisearch/index/search/multi_params_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
-    sleep(0.1)
+    response = @index.add_documents(@documents)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do
@@ -59,8 +59,8 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
   end
 
   it 'does a custom search with facetFilters, attributesToRetrieve and attributesToHighlight' do
-    @index.update_attributes_for_faceting(['genre'])
-    sleep(0.1)
+    response = @index.update_attributes_for_faceting(['genre'])
+    @index.wait_for_pending_update(response['updateId'])
     response = @index.search('prinec',
                              {
                                facetFilters: ['genre: fantasy'],
@@ -77,8 +77,8 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
   end
 
   it 'does a custom search with facetsDistribution and limit' do
-    @index.update_attributes_for_faceting(['genre'])
-    sleep(0.1)
+    response = @index.update_attributes_for_faceting(['genre'])
+    @index.wait_for_pending_update(response['updateId'])
     response = @index.search('prinec', facetsDistribution: ['genre'], limit: 1)
     expect(response.keys).to contain_exactly(
       *$DEFAULT_SEARCH_RESPONSE_KEYS,

--- a/spec/meilisearch/index/search/offset_spec.rb
+++ b/spec/meilisearch/index/search/offset_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe 'MeiliSearch::Index - Search with offset' do
 
   it 'does a custom placeholder search with an offset set to 3 and custom ranking rules' do
     response = @index.update_ranking_rules([
-                                  'typo',
-                                  'words',
-                                  'proximity',
-                                  'attribute',
-                                  'wordsPosition',
-                                  'exactness',
-                                  'asc(objectId)'
-                                ])
+                                             'typo',
+                                             'words',
+                                             'proximity',
+                                             'attribute',
+                                             'wordsPosition',
+                                             'exactness',
+                                             'asc(objectId)'
+                                           ])
     @index.wait_for_pending_update(response['updateId'])
     response = @index.search('')
     response_with_offset = @index.search('', offset: 3)

--- a/spec/meilisearch/index/search/offset_spec.rb
+++ b/spec/meilisearch/index/search/offset_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'MeiliSearch::Index - Search with offset' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
-    sleep(0.1)
+    response = @index.add_documents(@documents)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do
@@ -35,7 +35,7 @@ RSpec.describe 'MeiliSearch::Index - Search with offset' do
   end
 
   it 'does a custom placeholder search with an offset set to 3 and custom ranking rules' do
-    @index.update_ranking_rules([
+    response = @index.update_ranking_rules([
                                   'typo',
                                   'words',
                                   'proximity',
@@ -44,7 +44,7 @@ RSpec.describe 'MeiliSearch::Index - Search with offset' do
                                   'exactness',
                                   'asc(objectId)'
                                 ])
-    sleep(0.1)
+    @index.wait_for_pending_update(response['updateId'])
     response = @index.search('')
     response_with_offset = @index.search('', offset: 3)
     expect(response['hits'].first['objectId']).to eq(1)

--- a/spec/meilisearch/index/search/q_spec.rb
+++ b/spec/meilisearch/index/search/q_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'MeiliSearch::Index - Basic search' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('books')
-    @index.add_documents(@documents)
-    sleep(0.1)
+    response = @index.add_documents(@documents)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do
@@ -46,7 +46,7 @@ RSpec.describe 'MeiliSearch::Index - Basic search' do
   end
 
   it 'does a basic search with an empty query and a custom ranking rule' do
-    @index.update_ranking_rules([
+    response = @index.update_ranking_rules([
                                   'typo',
                                   'words',
                                   'proximity',
@@ -55,7 +55,7 @@ RSpec.describe 'MeiliSearch::Index - Basic search' do
                                   'exactness',
                                   'asc(objectId)'
                                 ])
-    sleep(0.1)
+    @index.wait_for_pending_update(response['updateId'])
     response = @index.search('')
     expect(response['nbHits']).to eq(@documents.count)
     expect(response['hits'].first['objectId']).to eq(1)

--- a/spec/meilisearch/index/search/q_spec.rb
+++ b/spec/meilisearch/index/search/q_spec.rb
@@ -47,14 +47,14 @@ RSpec.describe 'MeiliSearch::Index - Basic search' do
 
   it 'does a basic search with an empty query and a custom ranking rule' do
     response = @index.update_ranking_rules([
-                                  'typo',
-                                  'words',
-                                  'proximity',
-                                  'attribute',
-                                  'wordsPosition',
-                                  'exactness',
-                                  'asc(objectId)'
-                                ])
+                                             'typo',
+                                             'words',
+                                             'proximity',
+                                             'attribute',
+                                             'wordsPosition',
+                                             'exactness',
+                                             'asc(objectId)'
+                                           ])
     @index.wait_for_pending_update(response['updateId'])
     response = @index.search('')
     expect(response['nbHits']).to eq(@documents.count)

--- a/spec/meilisearch/index/settings_spec.rb
+++ b/spec/meilisearch/index/settings_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
         distinctAttribute: 'title'
       )
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       settings = index.settings
       expect(settings['rankingRules']).to eq(['asc(title)', 'typo'])
       expect(settings['distinctAttribute']).to eq('title')
@@ -69,7 +69,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'updates one setting without reset the others' do
       response = index.update_settings(stopWords: ['the'])
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       settings = index.settings
       expect(settings['rankingRules']).to eq(['asc(title)', 'typo'])
       expect(settings['distinctAttribute']).to eq('title')
@@ -80,7 +80,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'resets all settings' do
       response = index.reset_settings
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       settings = index.settings
       expect(settings['rankingRules']).to eq(default_ranking_rules)
       expect(settings['distinctAttribute']).to be_nil
@@ -109,7 +109,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'updates ranking rules' do
       response = index.update_ranking_rules(ranking_rules)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.ranking_rules).to eq(ranking_rules)
     end
 
@@ -122,7 +122,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'resets ranking rules' do
       response = index.reset_ranking_rules
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.ranking_rules).to eq(default_ranking_rules)
     end
   end
@@ -146,14 +146,14 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'updates distinct attribute' do
       response = index.update_distinct_attribute(distinct_attribute)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.distinct_attribute).to eq(distinct_attribute)
     end
 
     it 'resets distinct attribute' do
       response = index.reset_distinct_attribute
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.distinct_attribute).to be_nil
     end
   end
@@ -177,14 +177,14 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'updates searchable attributes' do
       response = index.update_searchable_attributes(searchable_attributes)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.searchable_attributes).to eq(searchable_attributes)
     end
 
     it 'resets searchable attributes' do
       response = index.reset_searchable_attributes
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.get_update_status(response['updateId'])['status']).to eq('processed')
       expect(index.searchable_attributes).to eq(default_searchable_attributes)
     end
@@ -209,14 +209,14 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'updates displayed attributes' do
       response = index.update_displayed_attributes(displayed_attributes)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.displayed_attributes).to contain_exactly(*displayed_attributes)
     end
 
     it 'resets displayed attributes' do
       response = index.reset_displayed_attributes
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.get_update_status(response['updateId'])['status']).to eq('processed')
       expect(index.displayed_attributes).to eq(default_displayed_attributes)
     end
@@ -249,7 +249,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       response = index.update_synonyms(synonyms)
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
     end
 
     it 'gets all the synonyms' do
@@ -265,7 +265,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       response = index.update_synonyms(hp: ['harry potter'], 'harry potter': ['hp'])
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       synonyms = index.synonyms
       expect(synonyms).to be_a(Hash)
       expect(synonyms.count).to eq(2)
@@ -278,7 +278,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       response = index.reset_synonyms
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       synonyms = index.synonyms
       expect(synonyms).to be_a(Hash)
       expect(synonyms).to be_empty
@@ -307,7 +307,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       response = index.update_stop_words(stop_words_array)
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
     end
 
     it 'gets list of stop-words' do
@@ -320,7 +320,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       response = index.update_stop_words(stop_words_string)
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       sw = index.stop_words
       expect(sw).to be_a(Array)
       expect(sw).to contain_exactly(stop_words_string)
@@ -336,7 +336,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       response = index.reset_stop_words
       expect(response).to be_a(Hash)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.stop_words).to be_a(Array)
       expect(index.stop_words).to be_empty
     end
@@ -362,14 +362,14 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'updates attributes for faceting' do
       response = index.update_attributes_for_faceting(attributes_for_faceting)
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.attributes_for_faceting).to contain_exactly(*attributes_for_faceting)
     end
 
     it 'resets attributes for faceting' do
       response = index.reset_attributes_for_faceting
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.get_update_status(response['updateId'])['status']).to eq('processed')
       expect(index.attributes_for_faceting).to be_empty
     end
@@ -403,7 +403,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
         distinctAttribute: 'title'
       )
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       settings = index.settings
       expect(settings['rankingRules']).to eq(['asc(title)', 'typo'])
       expect(settings['distinctAttribute']).to eq('title')
@@ -413,7 +413,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'updates one setting without reset the others' do
       response = index.update_settings(stopWords: ['the'])
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       settings = index.settings
       expect(settings['rankingRules']).to eq(['asc(title)', 'typo'])
       expect(settings['distinctAttribute']).to eq('title')
@@ -424,7 +424,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'resets all settings' do
       response = index.reset_settings
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       settings = index.settings
       expect(settings['rankingRules']).to eq(default_ranking_rules)
       expect(settings['distinctAttribute']).to be_nil
@@ -452,18 +452,18 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     it 'adds documents when there is a primary-key' do
       response = index.add_documents(objectId: 1, title: 'Test')
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.documents.count).to eq(1)
     end
 
     it 'resets searchable/displayed attributes' do
       response = index.reset_displayed_attributes
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.get_update_status(response['updateId'])['status']).to eq('processed')
       response = index.reset_searchable_attributes
       expect(response).to have_key('updateId')
-      sleep(0.1)
+      index.wait_for_pending_update(response['updateId'])
       expect(index.get_update_status(response['updateId'])['status']).to eq('processed')
       expect(index.searchable_attributes).to eq(['*'])
     end

--- a/spec/meilisearch/index/stats_spec.rb
+++ b/spec/meilisearch/index/stats_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'MeiliSearch::Index - Stats' do
     client = MeiliSearch::Client.new($URL, $MASTER_KEY)
     clear_all_indexes(client)
     @index = client.create_index('indexUID')
-    @index.add_documents(@documents)
-    sleep(0.1)
+    response = @index.add_documents(@documents)
+    @index.wait_for_pending_update(response['updateId'])
   end
 
   after(:all) do

--- a/spec/meilisearch/index/updates_spec.rb
+++ b/spec/meilisearch/index/updates_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'MeiliSearch::Index - Updates' do
   it 'gets update status after adding documents' do
     response = @index.add_documents(@documents)
     update_id = response['updateId']
-    sleep(0.2)
+    @index.wait_for_pending_update(update_id)
     response = @index.get_update_status(update_id)
     expect(response).to be_a(Hash)
     expect(response['updateId']).to eq(update_id)


### PR DESCRIPTION
Remove all the `sleep` methods in test suite, and replace them by `wait_for_pending_update` that makes sure the task is over and make the test suite synchronous 🎉 

Should be merged after #145 