### PR TITLE
Workflows renaming master to main

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - trying
       - staging
-      - master
+      - main
 
 jobs:
   integration_tests:


### PR DESCRIPTION
GitHub workflows should follow the `master` to `main` renaming from #149 