### PR TITLE
Add matrix for ruby versions in CI

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -10,18 +10,22 @@ on:
 
 jobs:
   integration_tests:
-    name: integration-tests-against-rc
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.6', '2.7']
+    name: integration-tests-against-rc (ruby ${{ matrix.ruby-version }})
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby-version }}
     - name: Install ruby dependencies
       run: bundle install --with test
     - name: Get the latest MeiliSearch RC
-      run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/master/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
+      run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/main/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
     - name: MeiliSearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
       run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_VERSION }} ./meilisearch --master-key=masterKey --no-analytics=true
     - name: Run test suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,17 +11,21 @@ on:
 
 jobs:
   integration_tests:
-    name: integration-tests
     # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
     # Will still run for each push to bump-meilisearch-v*
     if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.6', '2.7']
+    name: integration-tests (ruby ${{ matrix.ruby-version }})
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v2
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby-version }}
     - name: Install ruby dependencies
       run: bundle install --with test
     - name: MeiliSearch (latest) setup with Docker
@@ -33,11 +37,11 @@ jobs:
     name: linter-check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 3.0
     - name: Install ruby dependencies
       run: bundle install --with test
     - name: Run linter

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,7 @@
-status = ['integration-tests', 'linter-check']
+status = [
+  'integration-tests (ruby 2.6)',
+  'integration-tests (ruby 2.7)',
+  'linter-check'
+]
 # 1 hour timeout
 timeout-sec = 3600


### PR DESCRIPTION
- Use `ruby/ruby-setup` instead of `actions/ruby-setup` because deprecation
- Add matrix to test several ruby versions in CIs
- Update bors