### PR TITLE
Accept integer as a query parameter 

### DIFF
--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -116,7 +116,7 @@ module MeiliSearch
 
     def search(query, options = {})
       parsed_options = options.compact
-      http_post "/indexes/#{@uid}/search", { q: query }.merge(parsed_options)
+      http_post "/indexes/#{@uid}/search", { q: query.to_s }.merge(parsed_options)
     end
 
     ### UPDATES

--- a/spec/meilisearch/index/search/q_spec.rb
+++ b/spec/meilisearch/index/search/q_spec.rb
@@ -60,4 +60,12 @@ RSpec.describe 'MeiliSearch::Index - Basic search' do
     expect(response['nbHits']).to eq(@documents.count)
     expect(response['hits'].first['objectId']).to eq(1)
   end
+
+  it 'does a basic search with an integer query' do
+    response = @index.search(1)
+    expect(response).to be_a(Hash)
+    expect(response.keys).to contain_exactly(*$DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response['hits'].count).to eq(3)
+    expect(response['hits'].first).not_to have_key('_formatted')
+  end
 end


### PR DESCRIPTION
Add the conversion of a query to a string (issue 157) and add a unit test of that case