### PR TITLE
Added methods add_documents_in_batches, update_documents_in_batches and their tests

### DIFF
--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -76,6 +76,40 @@ module MeiliSearch
     end
     alias add_or_update_documents! update_documents!
 
+    def add_documents_in_batches(documents, batch_size = 1000, primary_key = nil)
+      update_ids = []
+      documents.each_slice(batch_size) do |batch|
+        update_ids.append(add_documents(batch, primary_key))
+      end
+      return update_ids
+    end
+
+    def add_documents_in_batches!(documents, batch_size = 1000, primary_key = nil)
+      update_ids = add_documents_in_batches(documents, batch_size, primary_key)
+      responses = []
+      update_ids.each do |update_object|
+        responses.append(wait_for_pending_update(update_object['updateId']))
+      end
+      return responses
+    end
+
+    def update_documents_in_batches(documents, batch_size = 1000, primary_key = nil)
+      update_ids = []
+      documents.each_slice(batch_size) do |batch|
+        update_ids.append(update_documents(batch, primary_key))
+      end
+      return update_ids
+    end
+
+    def update_documents_in_batches!(documents, batch_size = 1000, primary_key = nil)
+      update_ids = update_documents_in_batches(documents, batch_size, primary_key)
+      responses = []
+      update_ids.each do |update_object|
+        responses.append(wait_for_pending_update(update_object['updateId']))
+      end
+      return responses
+    end
+
     def delete_documents(documents_ids)
       if documents_ids.is_a?(Array)
         http_post "/indexes/#{@uid}/documents/delete-batch", documents_ids

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -81,7 +81,6 @@ module MeiliSearch
       documents.each_slice(batch_size) do |batch|
         update_ids.append(add_documents(batch, primary_key))
       end
-      return update_ids
     end
 
     def add_documents_in_batches!(documents, batch_size = 1000, primary_key = nil)
@@ -90,7 +89,6 @@ module MeiliSearch
       update_ids.each do |update_object|
         responses.append(wait_for_pending_update(update_object['updateId']))
       end
-      return responses
     end
 
     def update_documents_in_batches(documents, batch_size = 1000, primary_key = nil)
@@ -98,7 +96,6 @@ module MeiliSearch
       documents.each_slice(batch_size) do |batch|
         update_ids.append(update_documents(batch, primary_key))
       end
-      return update_ids
     end
 
     def update_documents_in_batches!(documents, batch_size = 1000, primary_key = nil)
@@ -107,7 +104,6 @@ module MeiliSearch
       update_ids.each do |update_object|
         responses.append(wait_for_pending_update(update_object['updateId']))
       end
-      return responses
     end
 
     def delete_documents(documents_ids)

--- a/spec/meilisearch/index/documents_spec.rb
+++ b/spec/meilisearch/index/documents_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       expect(response).to be_a(Array)
       expect(response.count).to eq(2) # 2 batches, since we start with 5 < documents.count <= 10 documents
       expect(response[0]).to have_key('updateId')
-      for response_object in response
-        index.wait_for_pending_update(response_object["updateId"])
+      response.each do |response_object|
+        index.wait_for_pending_update(response_object['updateId'])
       end
       expect(index.documents.count).to eq(documents.count)
     end
@@ -143,9 +143,9 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       response = index.update_documents_in_batches(updated_documents, 1)
       expect(response).to be_a(Array)
       expect(response.count).to eq(2)
-      for response_object in response
+      response.each do |response_object|
         expect(response_object).to have_key('updateId')
-        index.wait_for_pending_update(response_object["updateId"])
+        index.wait_for_pending_update(response_object['updateId'])
       end
 
       doc1 = index.document(id1)
@@ -179,7 +179,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       expect(doc2['title']).to eq(updated_documents.detect { |doc| doc[:objectId] == id2 }[:title])
       expect(doc2['comment']).to eq(documents.detect { |doc| doc[:objectId] == id2 }[:comment])
     end
-    
+
     it 'updates documents synchronously in index in batches (as an array of documents)' do
       id1 = 123
       id2 = 456
@@ -190,16 +190,14 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       response = index.update_documents_in_batches!(updated_documents, 1)
       expect(response).to be_a(Array)
       expect(response.count).to eq(2) # 2 batches, since we have two items with batch size 1
-      for response_object in response
+      response.each do |response_object|
         expect(response_object).to have_key('updateId')
         expect(response_object).to have_key('status')
         expect(response_object['status']).not_to eql('enqueued')
         expect(response_object['status']).to eql('processed')
       end
-      
       doc1 = index.document(id1)
       doc2 = index.document(id2)
-      
       expect(index.documents.count).to eq(documents.count)
       expect(doc1['title']).to eq(updated_documents.detect { |doc| doc[:objectId] == id1 }[:title])
       expect(doc1['comment']).to eq(documents.detect { |doc| doc[:objectId] == id1 }[:comment])


### PR DESCRIPTION
This pull request adds the following methods:

- add_documents_in_batches(documents, batch_size = 1000, primary_key = nil)
- update_documents_in_batches(documents, batch_size = 1000, primary_key = nil)

The tests for these methods are:

- adds documents in a batch (as a array of documents)
- adds document batches synchronously (as an array of documents)
- updates documents in index in batches
- updates documents synchronously in index in batches (as an array of documents)

They are based on their non-batch methods. There are two linter errors:

```
lib/meilisearch/index.rb:7:3: C: Metrics/ClassLength: Class has too many lines. [252/226]
  class Index < HTTPRequest ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^
spec/meilisearch/index/documents_spec.rb:3:1: C: Metrics/BlockLength: Block has too many lines. [500/497]
RSpec.describe 'MeiliSearch::Index - Documents' do ...
```

The linter indicates that there are too many lines for `documents_spec.rb` (which I was thinking of correcting by adding a new documents_batch_spec.rb, or the less clean way of changing the linter, etc), and that `index.rb` has too many lines (this one I am less sure of, as there aren't really any other classes that separate methods and since this is my first PR here, I don't want to introduce anything that might break something). I'm unsure, so I'd like to get some feedback on these.

References issue #218. 