### PR TITLE
Handle case when client returns a 500 error without a JSON response

### DIFF
--- a/lib/meilisearch/error.rb
+++ b/lib/meilisearch/error.rb
@@ -37,7 +37,7 @@ module MeiliSearch
       # We might receive a JSON::ParserError when, for example, MeiliSearch is running behind
       # some proxy (ELB or Nginx, for example), and the request timeouts, returning us
       # a raw HTML body instead of a JSON as we were expecting
-      @ms_message = "MeiliSearch API has not returned a valid JSON HTTP body: #{http_body}"
+      @ms_message = "The server has not returned a valid JSON HTTP body: #{http_body}"
     end
 
     def details


### PR DESCRIPTION
When MeiliSearch is running behind any reverse proxy and does not respond to the request in time, the gateway may return a plain HTTP error page. The client tries to parse such a response in order to determine if there are any errors and end up raising JSON::ParseError, because the proxies tend to return an HTML body.

Closes #88