### PR TITLE
Fix simplecov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,9 @@
 # it won't be able to track your files and their coverage!
 # The SimpleCov.start must be issued before any of your application code is required!
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+  add_filter %r{^/spec/}
+end
 
 require 'meilisearch'
 require 'byebug'


### PR DESCRIPTION
I was looking at the coverage stats, and noticed that Simplecov appears to be misconfigured. It only showed coverage for spec files.

I reordered the `require`s and added a note (from the SimpleCov repo) on why it is configured that way.
Additionally, I filtered out the spec files from the coverage report.

Here's screenshots before:

![Screen Shot 2021-10-20 at 9 43 36 AM](https://user-images.githubusercontent.com/4923990/138110072-a0194344-dcf1-47ba-a81d-bd02f88516e7.png)

and after:

<img width="791" alt="Screen Shot 2021-10-20 at 9 52 34 AM" src="https://user-images.githubusercontent.com/4923990/138110073-4f03fa93-6a51-4f02-b971-81cfdd764558.png">
