### PR TITLE
Update distinct_attribute_1 values in .code-samples.meilisearch.yaml

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -123,11 +123,11 @@ update_ranking_rules_1: |-
 reset_ranking_rules_1: |-
   client.index('movies').reset_ranking_rules
 get_distinct_attribute_1: |-
-  client.index('movies').distinct_attribute
+  client.index('shoes').distinct_attribute
 update_distinct_attribute_1: |-
-  client.index('movies').update_distinct_attribute('movie_id')
+  client.index('shoes').update_distinct_attribute('skuid')
 reset_distinct_attribute_1: |-
-  client.index('movies').reset_distinct_attribute
+  client.index('shoes').reset_distinct_attribute
 get_searchable_attributes_1: |-
   client.index('movies').searchable_attributes
 update_searchable_attributes_1: |-


### PR DESCRIPTION
This PR changes .code-samples.meilisearch.yaml in accordance with meilisearch/documentation#1214

- [x] `get_distinct_attribute_1` - change "movies" to "shoes"
- [x] `update_distinct_attribute_1` - change "movies" to "shoes"
- [x] `update_distinct_attribute_1` - change "movie_id" to "skuid"
- [x] `reset_distinct_attribute_1` - change "movies" to "shoes"

Closes #248 