### PR TITLE
Remove Content-Type from non-body HTTP methods

### DIFF
--- a/spec/meilisearch/index/base_spec.rb
+++ b/spec/meilisearch/index/base_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe MeiliSearch::Index do
     expect(MeiliSearch::Index).to receive(:get).with(
       "#{URL}/indexes/options",
       {
-        headers: { 'Content-Type' => 'application/json', 'X-Meili-API-Key' => MASTER_KEY },
+        headers: { 'X-Meili-API-Key' => MASTER_KEY },
         body: 'null',
         query: {},
         max_retries: 1,


### PR DESCRIPTION
- The non-body HTTP methods: GET and DELETE.
- Expose the headers as arg to make it explicit and move the decision/concern to each method instead of send_request.
- Use keywords args as there're multiple optional ones.
- Extract the non-body headers to a classes property to convey its intention with its name and reduce duplication.
- Duly update related test.

Closes the topic 1/3 of #243. It's a small step towards the other topics. Maybe they could even be bundled into a single PR, but I don't think it's mandatory.
>  Currently, the SDKs always send Content-Type: application/json to every request. Only the POST and PUT requests should send the Content-Type: application/json and not the DELETE and GET ones.