### PR TITLE
Changes due to error reformating

### DIFF
--- a/lib/meilisearch/error.rb
+++ b/lib/meilisearch/error.rb
@@ -29,10 +29,10 @@ module MeiliSearch
 
     def get_meilisearch_error_info(http_body)
       @http_body = JSON.parse(http_body)
-      @ms_code = @http_body['errorCode']
+      @ms_code = @http_body['code']
       @ms_message = @http_body['message']
-      @ms_type = @http_body['errorType']
-      @ms_link = @http_body['errorLink']
+      @ms_type = @http_body['type']
+      @ms_link = @http_body['link']
     rescue JSON::ParserError
       # We might receive a JSON::ParserError when, for example, MeiliSearch is running behind
       # some proxy (ELB or Nginx, for example), and the request timeouts, returning us

--- a/spec/meilisearch/client/dumps_spec.rb
+++ b/spec/meilisearch/client/dumps_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'MeiliSearch::Client - Dumps' do
   it 'fails to get dump status without uid' do
     expect do
       client.dump_status('uid_not_exists')
-    end.to raise_meilisearch_api_error_with(404, 'not_found', 'invalid_request_error')
+    end.to raise_meilisearch_api_error_with(404, 'not_found', 'invalid_request')
   end
 
   it 'works with method aliases' do

--- a/spec/meilisearch/client/indexes_spec.rb
+++ b/spec/meilisearch/client/indexes_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
 
         expect do
           client.create_index('existing_index')
-        end.to raise_meilisearch_api_error_with(400, 'index_already_exists', 'invalid_request_error')
+        end.to raise_meilisearch_api_error_with(409, 'index_already_exists', 'invalid_request')
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
       it 'raises an error' do
         expect do
           client.create_index('two words')
-        end.to raise_meilisearch_api_error_with(400, 'invalid_index_uid', 'invalid_request_error')
+        end.to raise_meilisearch_api_error_with(400, 'invalid_index_uid', 'invalid_request')
       end
     end
   end

--- a/spec/meilisearch/client/keys_spec.rb
+++ b/spec/meilisearch/client/keys_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'MeiliSearch::Client - Keys' do
     new_client = MeiliSearch::Client.new(URL, public_key)
     expect do
       new_client.index(random_uid).settings
-    end.to raise_meilisearch_api_error_with(403, 'invalid_token', 'authentication_error')
+    end.to raise_meilisearch_api_error_with(403, 'invalid_api_key', 'auth')
   end
 
   it 'fails to get keys if private key used' do
@@ -23,14 +23,14 @@ RSpec.describe 'MeiliSearch::Client - Keys' do
     new_client = MeiliSearch::Client.new(URL, private_key)
     expect do
       new_client.keys
-    end.to raise_meilisearch_api_error_with(403, 'invalid_token', 'authentication_error')
+    end.to raise_meilisearch_api_error_with(403, 'invalid_api_key', 'auth')
   end
 
   it 'fails to search if no key used' do
     new_client = MeiliSearch::Client.new(URL)
     expect do
       new_client.index(random_uid).settings
-    end.to raise_meilisearch_api_error_with(401, 'missing_authorization_header', 'authentication_error')
+    end.to raise_meilisearch_api_error_with(401, 'missing_authorization_header', 'auth')
   end
 
   it 'succeeds to search when using public key' do

--- a/spec/meilisearch/index/base_spec.rb
+++ b/spec/meilisearch/index/base_spec.rb
@@ -45,6 +45,19 @@ RSpec.describe MeiliSearch::Index do
   end
 
   it 'updates primary-key of index if not defined before' do
+    index = client.create_index('uid', primaryKey: 'primary_key')
+    index.update(primaryKey: 'new_primary_key')
+    expect(index).to be_a(MeiliSearch::Index)
+    expect(index.uid).to eq('uid')
+    expect(index.primary_key).to eq('new_primary_key')
+    expect(index.fetch_primary_key).to eq('new_primary_key')
+    expect(index.created_at).to be_a(Time)
+    expect(index.created_at).to be_within(60).of(Time.now)
+    expect(index.updated_at).to be_a(Time)
+    expect(index.updated_at).to be_within(60).of(Time.now)
+  end
+
+  it 'updates primary-key of index if has been defined before but there is not docs' do
     index = client.create_index('uid')
     index.update(primaryKey: 'new_primary_key')
     expect(index).to be_a(MeiliSearch::Index)
@@ -58,7 +71,9 @@ RSpec.describe MeiliSearch::Index do
   end
 
   it 'returns error if trying to update primary-key if it is already defined' do
-    index = client.create_index('uid', primaryKey: 'primary_key')
+    index = client.index('uid')
+    update = index.add_documents({ id: 1, title: 'My Title' })
+    index.wait_for_pending_update(update['updateId'])
     expect do
       index.update(primaryKey: 'new_primary_key')
     end.to raise_meilisearch_api_error_with(

--- a/spec/meilisearch/index/base_spec.rb
+++ b/spec/meilisearch/index/base_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe MeiliSearch::Index do
       index.update(primaryKey: 'new_primary_key')
     end.to raise_meilisearch_api_error_with(
       400,
-      'primary_key_already_present',
-      'invalid_request_error'
+      'index_primary_key_already_exists',
+      'invalid_request'
     )
   end
 

--- a/spec/meilisearch/index/documents_spec.rb
+++ b/spec/meilisearch/index/documents_spec.rb
@@ -486,7 +486,7 @@ RSpec.describe 'MeiliSearch::Index - Documents' do
       response = index.add_documents!(documents)
       update = index.get_update_status(response['updateId'])
       expect(update['status']).to eq('failed')
-      expect(update['errorCode']).to eq('missing_primary_key')
+      expect(update['code']).to eq('missing_primary_key')
     end
   end
 

--- a/spec/meilisearch/index/settings_spec.rb
+++ b/spec/meilisearch/index/settings_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       response = index.get_update_status(response['updateId'])
 
       expect(response.keys).to include('message')
-      expect(response['errorCode']).to eq('invalid_request')
+      expect(response['code']).to eq('invalid_request')
     end
 
     it 'resets ranking rules' do
@@ -563,7 +563,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       index.wait_for_pending_update(response['updateId'])
       response = index.get_update_status(response['updateId'])
       expect(response.keys).to include('message')
-      expect(response['errorCode']).to eq('missing_primary_key')
+      expect(response['code']).to eq('missing_primary_key')
     end
 
     it 'adds documents when there is a primary-key' do

--- a/spec/support/exceptions_helpers.rb
+++ b/spec/support/exceptions_helpers.rb
@@ -14,7 +14,7 @@ module ExceptionsHelpers
     raise_meilisearch_api_error_with(
       400,
       'bad_request',
-      'invalid_request_error'
+      'invalid_request'
     )
   end
 
@@ -22,7 +22,7 @@ module ExceptionsHelpers
     raise_meilisearch_api_error_with(
       404,
       'index_not_found',
-      'invalid_request_error'
+      'invalid_request'
     )
   end
 
@@ -30,7 +30,7 @@ module ExceptionsHelpers
     raise_meilisearch_api_error_with(
       404,
       'document_not_found',
-      'invalid_request_error'
+      'invalid_request'
     )
   end
 
@@ -38,7 +38,7 @@ module ExceptionsHelpers
     raise_meilisearch_api_error_with(
       400,
       'missing_primary_key',
-      'invalid_request_error'
+      'invalid_request'
     )
   end
 end


### PR DESCRIPTION
Rename `errorCode`, `errorType` and `errorLink` into `code`, `type` and `link` -> this is not breaking for the user this the attributes are not renamed
Also fixes tests due to new error naming.