### PR TITLE
Use `Authorization` header instead of `X-Meili-API-Key`

### DIFF
--- a/lib/meilisearch/http_request.rb
+++ b/lib/meilisearch/http_request.rb
@@ -15,10 +15,10 @@ module MeiliSearch
       @options = options
       @headers = {
         'Content-Type' => 'application/json',
-        'X-Meili-API-Key' => api_key
+        'Authorization' => "Bearer #{api_key}"
       }.compact
       @headers_no_body = {
-        'X-Meili-API-Key' => api_key
+        'Authorization' => "Bearer #{api_key}"
       }.compact
     end
 

--- a/spec/meilisearch/index/base_spec.rb
+++ b/spec/meilisearch/index/base_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe MeiliSearch::Index do
     expect(MeiliSearch::Index).to receive(:get).with(
       "#{URL}/indexes/options",
       {
-        headers: { 'X-Meili-API-Key' => MASTER_KEY },
+        headers: { 'Authorization' => "Bearer #{MASTER_KEY}" },
         body: 'null',
         query: {},
         max_retries: 1,


### PR DESCRIPTION
According to v0.25.0, MeiliSearch will use
```
Authorization: Bearer <API key>
```

instead of 
```
X-Meili-API-key: <API key>
```

Tests are failing because of the other changes regarding v0.25.0