### PR TITLE
Remove `get_or_create_index` method

### DIFF
--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -32,17 +32,6 @@ module MeiliSearch
       wait_for_task(task['uid'])
     end
 
-    # def get_or_create_index(index_uid, options = {})
-    #   begin
-    #     index_instance = fetch_index(index_uid)
-    #   rescue ApiError => e
-    #     raise e unless e.code == 'index_not_found'
-
-    #     index_instance = create_index(index_uid, options)
-    #   end
-    #   index_instance
-    # end
-
     def delete_index(index_uid)
       index_object(index_uid).delete
     end

--- a/spec/meilisearch/client/indexes_spec.rb
+++ b/spec/meilisearch/client/indexes_spec.rb
@@ -105,38 +105,6 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     end
   end
 
-  # describe '#get_or_create_index' do
-  #   it 'creates a new index' do
-  #     expect do
-  #       new_index = client.get_or_create_index('new_index')
-
-  #       expect(new_index).to be_a(MeiliSearch::Index)
-  #     end.to change { client.indexes.length }.by(1)
-
-  #     found_index = client.fetch_index('new_index')
-  #     expect(found_index.uid).to eq('new_index')
-  #     expect(found_index.primary_key).to be_nil
-  #   end
-
-  #   it 'gets an index that already exists' do
-  #     client.create_index('existing_index')
-
-  #     expect do
-  #       client.get_or_create_index('existing_index')
-  #     end.not_to(change { client.indexes.length })
-  #   end
-
-  #   context 'when a primary key is provided' do
-  #     it 'creates a new index' do
-  #       expect do
-  #         index = client.get_or_create_index('new_index', primaryKey: 'primary_key')
-
-  #         expect(index).to be_a(MeiliSearch::Index)
-  #       end.to change { client.indexes.length }.by(1)
-  #     end
-  #   end
-  # end
-
   describe '#indexes' do
     it 'returns MeiliSearch::Index objects' do
       client.create_index!('index')


### PR DESCRIPTION
Why?

The first goal of this method was to avoid raising an instant error when trying to create an index that already exists.
Since MeiliSearch v0.25.0, the index creation is asynchronous and will not raise any instant error anymore.