### PR TITLE
Remove `delete_index_if_exists` method

### DIFF
--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -36,17 +36,6 @@ module MeiliSearch
       index_object(index_uid).delete
     end
 
-    # # Usage:
-    # # client.delete_index_if_exists('indexUID')
-    # def delete_index_if_exists(index_uid)
-    #   index_object(index_uid).delete
-    #   true
-    # rescue ApiError => e
-    #   raise e if e.code != 'index_not_found'
-
-    #   false
-    # end
-
     # Usage:
     # client.index('indexUID')
     def index(index_uid)


### PR DESCRIPTION
Why?

The first goal of this method was to avoid raising an instant error when trying to delete an index that does not exist.
Since MeiliSearch v0.25.0, the index deletion is asynchronous and will not raise any instant error anymore.