### PR TITLE
Simplify headers handling

### DIFF
--- a/lib/meilisearch/http_request.rb
+++ b/lib/meilisearch/http_request.rb
@@ -26,9 +26,11 @@ module MeiliSearch
       send_request(
         proc { |path, config| self.class.get(path, config) },
         relative_path,
-        query_params: query_params,
-        headers: remove_headers(@headers.dup, 'Content-Type'),
-        options: @options
+        config: {
+          query_params: query_params,
+          headers: remove_headers(@headers.dup, 'Content-Type'),
+          options: @options
+        }
       )
     end
 
@@ -36,10 +38,12 @@ module MeiliSearch
       send_request(
         proc { |path, config| self.class.post(path, config) },
         relative_path,
-        query_params: query_params,
-        body: body,
-        headers: @headers.dup.merge(options[:headers] || {}),
-        options: @options.merge(options)
+        config: {
+          query_params: query_params,
+          body: body,
+          headers: @headers.dup.merge(options[:headers] || {}),
+          options: @options.merge(options)
+        }
       )
     end
 
@@ -47,10 +51,12 @@ module MeiliSearch
       send_request(
         proc { |path, config| self.class.put(path, config) },
         relative_path,
-        query_params: query_params,
-        body: body,
-        headers: @headers,
-        options: @options
+        config: {
+          query_params: query_params,
+          body: body,
+          headers: @headers,
+          options: @options
+        }
       )
     end
 
@@ -58,10 +64,12 @@ module MeiliSearch
       send_request(
         proc { |path, config| self.class.patch(path, config) },
         relative_path,
-        query_params: query_params,
-        body: body,
-        headers: @headers,
-        options: @options
+        config: {
+          query_params: query_params,
+          body: body,
+          headers: @headers,
+          options: @options
+        }
       )
     end
 
@@ -69,8 +77,10 @@ module MeiliSearch
       send_request(
         proc { |path, config| self.class.delete(path, config) },
         relative_path,
-        headers: remove_headers(@headers.dup, 'Content-Type'),
-        options: @options
+        config: {
+          headers: remove_headers(@headers.dup, 'Content-Type'),
+          options: @options
+        }
       )
     end
 
@@ -87,13 +97,15 @@ module MeiliSearch
       data.delete_if { |k| keys.include?(k) }
     end
 
-    def send_request(http_method, relative_path, query_params: nil, body: nil, options: {}, headers: {})
-      config = http_config(query_params, body, options, headers)
+    def send_request(http_method, relative_path, config: {})
+      config = http_config(config[:query_params], config[:body], config[:options], config[:headers])
+
       begin
         response = http_method.call(@base_url + relative_path, config)
       rescue Errno::ECONNREFUSED => e
         raise CommunicationError, e.message
       end
+
       validate(response)
     end
 

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -81,7 +81,7 @@ module MeiliSearch
     alias add_or_replace_documents! add_documents!
 
     def add_documents_json(documents, primary_key = nil)
-      options = { headers: { 'Content-Type' => 'application/json' }, convert_body?: false }
+      options = { convert_body?: false }
       http_post "/indexes/#{@uid}/documents", documents, { primaryKey: primary_key }.compact, options
     end
     alias replace_documents_json add_documents_json

--- a/spec/meilisearch/index/base_spec.rb
+++ b/spec/meilisearch/index/base_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe MeiliSearch::Index do
   it 'supports options' do
     options = { timeout: 2, max_retries: 1 }
     expected_headers = {
-      'Authorization' => "Bearer #{MASTER_KEY}",
+      'Authorization' => "Bearer #{MASTER_KEY}"
     }
 
     new_client = MeiliSearch::Client.new(URL, MASTER_KEY, options)

--- a/spec/meilisearch/index/base_spec.rb
+++ b/spec/meilisearch/index/base_spec.rb
@@ -101,23 +101,19 @@ RSpec.describe MeiliSearch::Index do
 
   it 'supports options' do
     options = { timeout: 2, max_retries: 1 }
+    expected_headers = {
+      'Authorization' => "Bearer #{MASTER_KEY}",
+    }
+
     new_client = MeiliSearch::Client.new(URL, MASTER_KEY, options)
     new_client.create_index!('options')
     index = new_client.fetch_index('options')
-    expect(index.options).to eq({
-                                  headers: {
-                                    'Content-Type' => 'application/json',
-                                    'Authorization' => "Bearer #{MASTER_KEY}"
-                                  },
-                                  max_retries: 1,
-                                  timeout: 2,
-                                  convert_body?: true
-                                })
+    expect(index.options).to eq({ max_retries: 1, timeout: 2, convert_body?: true })
 
     expect(MeiliSearch::Index).to receive(:get).with(
       "#{URL}/indexes/options",
       {
-        headers: { 'Authorization' => "Bearer #{MASTER_KEY}" },
+        headers: expected_headers,
         body: 'null',
         query: {},
         max_retries: 1,


### PR DESCRIPTION
This improvement creates a new attr to be instantiated during the initializer phase and after the instantiation, it could not be updated directly, just copies of it using `dup`.
This should simplify the headers handling since they were mixed with options.

Originally extracted from https://github.com/meilisearch/meilisearch-ruby/pull/292