### PR TITLE
Remove openssl from meilisearch.gemspec

### DIFF
--- a/lib/meilisearch/tenant_token.rb
+++ b/lib/meilisearch/tenant_token.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'openssl/hmac'
-
 module MeiliSearch
   module TenantToken
     HEADER = {

--- a/meilisearch.gemspec
+++ b/meilisearch.gemspec
@@ -16,5 +16,4 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.6.0'
   s.add_dependency 'httparty', '>= 0.17.1', '< 0.21.0'
-  s.add_dependency 'openssl'
 end


### PR DESCRIPTION
Remove the `openssl` gem from gemspec. We do not need it, because `openssl` gem is part of the ruby stdlib.

And because before I was explicitly requiring `openssl/hmac` which only can be found in the versions greater than 2.2.0 from `openssl` gem. 

ruby 3 comes with openssl v2.2.0 and ruby 2.6 comes with openssl 2.1.2