### PR TITLE
Create a helper module to reduce test duplication

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -130,6 +130,7 @@ RSpec.configure do |config|
 
   # Helpers
   config.include IndexesHelpers
+  config.include TaskHelpers
   config.include ExceptionsHelpers
   config.include DumpsHelpers
 end

--- a/spec/support/task_helpers.rb
+++ b/spec/support/task_helpers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module TaskHelpers
+  def wait_for_it(task)
+    raise('The param `task` does not have an uid key.') unless task.key?('uid')
+
+    client.wait_for_task(task['uid'])
+  end
+end


### PR DESCRIPTION
The general idea is to change tests from this:

```rb
  it 'searches with index with searchableAttributes setting' do
    response = index.update_searchable_attributes(['title', 'info.comment'])
    index.wait_for_task(response['uid'])
    response = index.add_documents(documents)
    index.wait_for_task(response['uid'])

    response = index.search('An awesome')

    expect(response['hits'].count).to eq(1)
  end
```

to this:

```rb
  it 'searches with index with searchableAttributes setting' do
    index.update_searchable_attributes(['title', 'info.comment']).then(&method(:wait_for_it))
    index.add_documents(documents).then(&method(:wait_for_it))

    response = index.search('An awesome')

    expect(response['hits'].count).to eq(1)
  end
```

or this: 

```rb
  it 'searches with index with searchableAttributes setting' do
    wait_for_it index.update_searchable_attributes(['title', 'info.comment'])
    wait_for_it index.add_documents(documents)

    response = index.search('An awesome')

    expect(response['hits'].count).to eq(1)
  end
```