### PR TITLE
Add new search parameters highlightPreTag, highlightPostTag and cropMarker

### DIFF
--- a/spec/meilisearch/index/search/attributes_to_crop_spec.rb
+++ b/spec/meilisearch/index/search/attributes_to_crop_spec.rb
@@ -12,6 +12,41 @@ RSpec.describe 'MeiliSearch::Index - Cropped search' do
 
   before { index.add_documents!(document) }
 
+  it 'searches with default cropping params' do
+    response = index.search('galaxy', attributesToCrop: ['*'], cropLength: 6)
+
+    expect(response.dig('hits', 0, '_formatted', 'description')).to eq('…Guide to the Galaxy is a…')
+  end
+
+  it 'searches with custom crop markers' do
+    response = index.search('galaxy', attributesToCrop: ['*'], cropLength: 6, cropMarker: '(ꈍᴗꈍ)')
+
+    expect(response.dig('hits', 0, '_formatted', 'description')).to eq('(ꈍᴗꈍ)Guide to the Galaxy is a(ꈍᴗꈍ)')
+  end
+
+  it 'searches with mixed highlight and crop config' do
+    response = index.search(
+      'galaxy',
+      attributesToHighlight: ['*'],
+      attributesToCrop: ['*'],
+      highlightPreTag: '<span class="bold">'
+    )
+
+    expect(response.dig('hits', 0, '_formatted', 'description')).to \
+      eq("…Hitchhiker's Guide to the <span class=\"bold\">Galaxy</em> is a comedy science…")
+  end
+
+  it 'searches with highlight tags' do
+    response = index.search(
+      'galaxy',
+      attributesToHighlight: ['*'],
+      highlightPreTag: '<span>',
+      highlightPostTag: '</span>'
+    )
+
+    expect(response.dig('hits', 0, '_formatted', 'description')).to include('<span>Galaxy</span>')
+  end
+
   it 'does a custom search with attributes to crop' do
     response = index.search('galaxy', { attributesToCrop: ['description'], cropLength: 6 })
     expect(response['hits'].first).to have_key('_formatted')


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2214 new search parameters are introduced:

- `highlightPreTag`
- `highlightPostTag`
- `cropMarker`

This PR adds tests to ensure the new parameters are working.