### PR TITLE
Update version for the next release (v0.18.3)

### DIFF
--- a/lib/meilisearch/version.rb
+++ b/lib/meilisearch/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module MeiliSearch
-  VERSION = '0.18.2'
+  VERSION = '0.18.3'
 
   def self.qualified_version
     "Meilisearch Ruby (v#{VERSION})"


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.27.0 :tada:
Check out the changelog of [Meilisearch v0.27.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.27.0) for more information on the changes.

## 🚀 Enhancements

* Ensure nested field support (#318) @brunoocasali
* Add `highlightPreTag`, `highlightPostTag`, `cropMarker`, parameters in the search request (#319) @brunoocasali
* Create a helper module to reduce test duplication (#316) @brunoocasali

## 🐛 Bug Fixes

* Improve error handling, rescue EPIPE and Net::* errors (#307) @brunoocasali

Thanks again to @brunoocasali! 🎉
