### PR TITLE
Apply naming changes for search endpoint

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -245,7 +245,7 @@ search_parameter_guide_highlight_tag_1: |-
   })
 search_parameter_guide_matches_1: |-
   client.index('movies').search('winter feast', {
-    matches: true
+    show_matches_position: true
   })
 settings_guide_synonyms_1: |-
   client.index('tops').update_settings({

--- a/README.md
+++ b/README.md
@@ -187,8 +187,7 @@ JSON output:
       ]
     }
   ],
-  "nbHits": 1,
-  "exhaustiveNbHits": false,
+  "estimatedNbHits": 1,
   "query": "wonder",
   "limit": 20,
   "offset": 0,

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ JSON output:
       ]
     }
   ],
-  "estimatedNbHits": 1,
+  "estimatedTotalHits": 1,
   "query": "wonder",
   "limit": 20,
   "offset": 0,

--- a/spec/meilisearch/index/search/facets_distribution_spec.rb
+++ b/spec/meilisearch/index/search/facets_distribution_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'MeiliSearch::Index - Search with facets' do
       *DEFAULT_SEARCH_RESPONSE_KEYS,
       'facetDistribution'
     )
-    expect(response['estimatedNbHits']).to eq(2)
+    expect(response['estimatedTotalHits']).to eq(2)
     expect(response['facetDistribution'].keys).to contain_exactly('genre', 'author')
     expect(response['facetDistribution']['genre'].keys).to contain_exactly('adventure', 'fantasy')
     expect(response['facetDistribution']['genre']['adventure']).to eq(1)
@@ -29,7 +29,7 @@ RSpec.describe 'MeiliSearch::Index - Search with facets' do
       *DEFAULT_SEARCH_RESPONSE_KEYS,
       'facetDistribution'
     )
-    expect(response['estimatedNbHits']).to eq(documents.count)
+    expect(response['estimatedTotalHits']).to eq(documents.count)
     expect(response['facetDistribution'].keys).to contain_exactly('genre', 'author')
     expect(response['facetDistribution']['genre'].keys).to contain_exactly('romance', 'adventure', 'fantasy')
     expect(response['facetDistribution']['genre']['romance']).to eq(2)
@@ -44,7 +44,7 @@ RSpec.describe 'MeiliSearch::Index - Search with facets' do
       *DEFAULT_SEARCH_RESPONSE_KEYS,
       'facetDistribution'
     )
-    expect(response['estimatedNbHits']).to eq(documents.count)
+    expect(response['estimatedTotalHits']).to eq(documents.count)
     expect(response['facetDistribution'].keys).to contain_exactly('year')
     expect(response['facetDistribution']['year'].keys).to contain_exactly(*documents.map { |o| o[:year].to_s })
     expect(response['facetDistribution']['year']['1943']).to eq(1)

--- a/spec/meilisearch/index/search/facets_distribution_spec.rb
+++ b/spec/meilisearch/index/search/facets_distribution_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'MeiliSearch::Index - Search with facetsDistribution' do
+RSpec.describe 'MeiliSearch::Index - Search with facets' do
   include_context 'search books with author, genre, year'
 
   before do
@@ -8,51 +8,45 @@ RSpec.describe 'MeiliSearch::Index - Search with facetsDistribution' do
     index.wait_for_task(response['uid'])
   end
 
-  it 'does a custom search with facetsDistribution' do
-    response = index.search('prinec', facetsDistribution: ['genre', 'author'])
+  it 'does a custom search with facets' do
+    response = index.search('prinec', facets: ['genre', 'author'])
     expect(response.keys).to contain_exactly(
       *DEFAULT_SEARCH_RESPONSE_KEYS,
-      'facetsDistribution',
-      'exhaustiveFacetsCount'
+      'facetDistribution'
     )
-    expect(response['exhaustiveFacetsCount']).to be false
-    expect(response['nbHits']).to eq(2)
-    expect(response['facetsDistribution'].keys).to contain_exactly('genre', 'author')
-    expect(response['facetsDistribution']['genre'].keys).to contain_exactly('adventure', 'fantasy')
-    expect(response['facetsDistribution']['genre']['adventure']).to eq(1)
-    expect(response['facetsDistribution']['genre']['fantasy']).to eq(1)
-    expect(response['facetsDistribution']['author']['J. K. Rowling']).to eq(1)
-    expect(response['facetsDistribution']['author']['Antoine de Saint-Exupéry']).to eq(1)
+    expect(response['estimatedNbHits']).to eq(2)
+    expect(response['facetDistribution'].keys).to contain_exactly('genre', 'author')
+    expect(response['facetDistribution']['genre'].keys).to contain_exactly('adventure', 'fantasy')
+    expect(response['facetDistribution']['genre']['adventure']).to eq(1)
+    expect(response['facetDistribution']['genre']['fantasy']).to eq(1)
+    expect(response['facetDistribution']['author']['J. K. Rowling']).to eq(1)
+    expect(response['facetDistribution']['author']['Antoine de Saint-Exupéry']).to eq(1)
   end
 
-  it 'does a placeholder search with facetsDistribution' do
-    response = index.search('', facetsDistribution: ['genre', 'author'])
+  it 'does a placeholder search with facets' do
+    response = index.search('', facets: ['genre', 'author'])
     expect(response.keys).to contain_exactly(
       *DEFAULT_SEARCH_RESPONSE_KEYS,
-      'facetsDistribution',
-      'exhaustiveFacetsCount'
+      'facetDistribution'
     )
-    expect(response['exhaustiveFacetsCount']).to be false
-    expect(response['nbHits']).to eq(documents.count)
-    expect(response['facetsDistribution'].keys).to contain_exactly('genre', 'author')
-    expect(response['facetsDistribution']['genre'].keys).to contain_exactly('romance', 'adventure', 'fantasy')
-    expect(response['facetsDistribution']['genre']['romance']).to eq(2)
-    expect(response['facetsDistribution']['genre']['adventure']).to eq(3)
-    expect(response['facetsDistribution']['genre']['fantasy']).to eq(3)
-    expect(response['facetsDistribution']['author']['J. K. Rowling']).to eq(2)
+    expect(response['estimatedNbHits']).to eq(documents.count)
+    expect(response['facetDistribution'].keys).to contain_exactly('genre', 'author')
+    expect(response['facetDistribution']['genre'].keys).to contain_exactly('romance', 'adventure', 'fantasy')
+    expect(response['facetDistribution']['genre']['romance']).to eq(2)
+    expect(response['facetDistribution']['genre']['adventure']).to eq(3)
+    expect(response['facetDistribution']['genre']['fantasy']).to eq(3)
+    expect(response['facetDistribution']['author']['J. K. Rowling']).to eq(2)
   end
 
-  it 'does a placeholder search with facetsDistribution on number' do
-    response = index.search('', facetsDistribution: ['year'])
+  it 'does a placeholder search with facets on number' do
+    response = index.search('', facets: ['year'])
     expect(response.keys).to contain_exactly(
       *DEFAULT_SEARCH_RESPONSE_KEYS,
-      'facetsDistribution',
-      'exhaustiveFacetsCount'
+      'facetDistribution'
     )
-    expect(response['exhaustiveFacetsCount']).to be false
-    expect(response['nbHits']).to eq(documents.count)
-    expect(response['facetsDistribution'].keys).to contain_exactly('year')
-    expect(response['facetsDistribution']['year'].keys).to contain_exactly(*documents.map { |o| o[:year].to_s })
-    expect(response['facetsDistribution']['year']['1943']).to eq(1)
+    expect(response['estimatedNbHits']).to eq(documents.count)
+    expect(response['facetDistribution'].keys).to contain_exactly('year')
+    expect(response['facetDistribution']['year'].keys).to contain_exactly(*documents.map { |o| o[:year].to_s })
+    expect(response['facetDistribution']['year']['1943']).to eq(1)
   end
 end

--- a/spec/meilisearch/index/search/filter_spec.rb
+++ b/spec/meilisearch/index/search/filter_spec.rb
@@ -46,14 +46,14 @@ RSpec.describe 'MeiliSearch::Index - Filtered search' do
   it 'does a custom search with filter and array syntax' do
     response = index.search('prinec', filter: ['genre = fantasy'])
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
-    expect(response['nbHits']).to eq(1)
+    expect(response['estimatedNbHits']).to eq(1)
     expect(response['hits'][0]['objectId']).to eq(4)
   end
 
   it 'does a custom search with multiple filter and array syntax' do
     response = index.search('potter', filter: ['genre = fantasy', ['year = 2005']])
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
-    expect(response['nbHits']).to eq(1)
+    expect(response['estimatedNbHits']).to eq(1)
     expect(response['hits'][0]['objectId']).to eq(4)
   end
 end

--- a/spec/meilisearch/index/search/filter_spec.rb
+++ b/spec/meilisearch/index/search/filter_spec.rb
@@ -46,14 +46,14 @@ RSpec.describe 'MeiliSearch::Index - Filtered search' do
   it 'does a custom search with filter and array syntax' do
     response = index.search('prinec', filter: ['genre = fantasy'])
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
-    expect(response['estimatedNbHits']).to eq(1)
+    expect(response['estimatedTotalHits']).to eq(1)
     expect(response['hits'][0]['objectId']).to eq(4)
   end
 
   it 'does a custom search with multiple filter and array syntax' do
     response = index.search('potter', filter: ['genre = fantasy', ['year = 2005']])
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
-    expect(response['estimatedNbHits']).to eq(1)
+    expect(response['estimatedTotalHits']).to eq(1)
     expect(response['hits'][0]['objectId']).to eq(4)
   end
 end

--- a/spec/meilisearch/index/search/matches_spec.rb
+++ b/spec/meilisearch/index/search/matches_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'MeiliSearch::Index - Search with showMatchesPosition' do
   include_context 'search books with genre'
 
   it 'does a custom search with showMatchesPosition' do
-    response = index.search('the', showMatchesPosition: true)
+    response = index.search('the', show_matches_position: true)
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].first).to have_key('_matchesPosition')
@@ -12,7 +12,7 @@ RSpec.describe 'MeiliSearch::Index - Search with showMatchesPosition' do
   end
 
   it 'does a placeholder search with showMatchesPosition' do
-    response = index.search('', showMatchesPosition: true)
+    response = index.search('', show_matches_position: true)
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].first).to have_key('_matchesPosition')

--- a/spec/meilisearch/index/search/matches_spec.rb
+++ b/spec/meilisearch/index/search/matches_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-RSpec.describe 'MeiliSearch::Index - Search with matches' do
+RSpec.describe 'MeiliSearch::Index - Search with showMatchesPosition' do
   include_context 'search books with genre'
 
-  it 'does a custom search with matches' do
-    response = index.search('the', matches: true)
+  it 'does a custom search with showMatchesPosition' do
+    response = index.search('the', showMatchesPosition: true)
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
-    expect(response['hits'].first).to have_key('_matchesInfo')
-    expect(response['hits'].first['_matchesInfo']).to have_key('title')
+    expect(response['hits'].first).to have_key('_matchesPosition')
+    expect(response['hits'].first['_matchesPosition']).to have_key('title')
   end
 
-  it 'does a placeholder search with matches' do
-    response = index.search('', matches: true)
+  it 'does a placeholder search with showMatchesPosition' do
+    response = index.search('', showMatchesPosition: true)
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
-    expect(response['hits'].first).to have_key('_matchesInfo')
+    expect(response['hits'].first).to have_key('_matchesPosition')
   end
 end

--- a/spec/meilisearch/index/search/multi_params_spec.rb
+++ b/spec/meilisearch/index/search/multi_params_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
                               attributesToHighlight: ['*']
                             })
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
-    expect(response['estimatedNbHits']).to eq(1)
+    expect(response['estimatedTotalHits']).to eq(1)
     expect(response['hits'].first).to have_key('_formatted')
     expect(response['hits'].first).not_to have_key('objectId')
     expect(response['hits'].first).not_to have_key('genre')
@@ -70,7 +70,7 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
       *DEFAULT_SEARCH_RESPONSE_KEYS,
       'facetDistribution'
     )
-    expect(response['estimatedNbHits']).to eq(2)
+    expect(response['estimatedTotalHits']).to eq(2)
     expect(response['hits'].count).to eq(1)
     expect(response['facetDistribution'].keys).to contain_exactly('genre')
     expect(response['facetDistribution']['genre'].keys).to contain_exactly('adventure', 'fantasy')

--- a/spec/meilisearch/index/search/multi_params_spec.rb
+++ b/spec/meilisearch/index/search/multi_params_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
                               attributesToHighlight: ['*']
                             })
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
-    expect(response['nbHits']).to eq(1)
+    expect(response['estimatedNbHits']).to eq(1)
     expect(response['hits'].first).to have_key('_formatted')
     expect(response['hits'].first).not_to have_key('objectId')
     expect(response['hits'].first).not_to have_key('genre')
@@ -62,22 +62,20 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
     expect(response['hits'].first['_formatted']['title']).to eq('Harry Potter and the Half-Blood <em>Princ</em>e')
   end
 
-  it 'does a custom search with facetsDistribution and limit' do
+  it 'does a custom search with facets and limit' do
     response = index.update_filterable_attributes(['genre'])
     index.wait_for_task(response['uid'])
-    response = index.search('prinec', facetsDistribution: ['genre'], limit: 1)
+    response = index.search('prinec', facets: ['genre'], limit: 1)
     expect(response.keys).to contain_exactly(
       *DEFAULT_SEARCH_RESPONSE_KEYS,
-      'facetsDistribution',
-      'exhaustiveFacetsCount'
+      'facetDistribution'
     )
-    expect(response['nbHits']).to eq(2)
+    expect(response['estimatedNbHits']).to eq(2)
     expect(response['hits'].count).to eq(1)
-    expect(response['facetsDistribution'].keys).to contain_exactly('genre')
-    expect(response['facetsDistribution']['genre'].keys).to contain_exactly('adventure', 'fantasy')
-    expect(response['facetsDistribution']['genre']['adventure']).to eq(1)
-    expect(response['facetsDistribution']['genre']['fantasy']).to eq(1)
-    expect(response['exhaustiveFacetsCount']).to be false
+    expect(response['facetDistribution'].keys).to contain_exactly('genre')
+    expect(response['facetDistribution']['genre'].keys).to contain_exactly('adventure', 'fantasy')
+    expect(response['facetDistribution']['genre']['adventure']).to eq(1)
+    expect(response['facetDistribution']['genre']['fantasy']).to eq(1)
   end
 
   context 'with snake_case options' do

--- a/spec/meilisearch/index/search/q_spec.rb
+++ b/spec/meilisearch/index/search/q_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'MeiliSearch::Index - Basic search' do
                                           ])
     index.wait_for_task(response['uid'])
     response = index.search('')
-    expect(response['nbHits']).to eq(documents.count)
+    expect(response['estimatedNbHits']).to eq(documents.count)
     expect(response['hits'].first['objectId']).to eq(1)
   end
 

--- a/spec/meilisearch/index/search/q_spec.rb
+++ b/spec/meilisearch/index/search/q_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'MeiliSearch::Index - Basic search' do
                                           ])
     index.wait_for_task(response['uid'])
     response = index.search('')
-    expect(response['estimatedNbHits']).to eq(documents.count)
+    expect(response['estimatedTotalHits']).to eq(documents.count)
     expect(response['hits'].first['objectId']).to eq(1)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,8 +35,7 @@ DEFAULT_SEARCH_RESPONSE_KEYS = [
   'hits',
   'offset',
   'limit',
-  'nbHits',
-  'exhaustiveNbHits',
+  'estimatedNbHits',
   'processingTimeMs',
   'query'
 ].freeze

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ DEFAULT_SEARCH_RESPONSE_KEYS = [
   'hits',
   'offset',
   'limit',
-  'estimatedNbHits',
+  'estimatedTotalHits',
   'processingTimeMs',
   'query'
 ].freeze


### PR DESCRIPTION
This is breaking because it enforces the users to use Meilisearch v0.28.0 regarding the new names

- Rename `nbHits` response parameter to `estimatedTotalHits`.
- Delete `exhaustiveNbHits` response parameter.
- Delete `exhaustiveFacetsCount` response parameter.
- `matches` request parameter is renamed `showMatchesPosition`.
- `_matchesInfo` response parameter is renamed `_matchesPosition`.
- `facetsDistribution` request parameter is renamed `facets`.
- `facetsDistribution` response parameter is renamed `facetDistribution`.