### PR TITLE
Documents changes v1

### DIFF
--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -11,7 +11,7 @@ module MeiliSearch
     end
 
     def indexes
-      raw_indexes.map do |index_hash|
+      raw_indexes['results'].map do |index_hash|
         index_object(index_hash['uid'], index_hash['primaryKey'])
       end
     end

--- a/spec/meilisearch/client/indexes_spec.rb
+++ b/spec/meilisearch/client/indexes_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     it 'returns raw indexes' do
       client.create_index!('index')
 
-      response = client.raw_indexes.first
+      response = client.raw_indexes['results'].first
 
       expect(response).to be_a(Hash)
       expect(response['uid']).to eq('index')
@@ -150,7 +150,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     it 'gets a list of raw indexes' do
       ['first_index', 'second_index', 'third_index'].each { |name| client.create_index!(name) }
 
-      indexes = client.raw_indexes
+      indexes = client.raw_indexes['results']
 
       expect(indexes).to be_a(Array)
       expect(indexes.length).to eq(3)


### PR DESCRIPTION
- This includes some missing `uid` to `taskUid` changes
- Moves from `index.documents` to `index.documents['results']`.
- Moves from `index.indexes` to `index.indexes['results']`.