### PR TITLE
Keys changes v2

### DIFF
--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -52,8 +52,10 @@ module MeiliSearch
 
     ### KEYS
 
-    def keys
-      http_get '/keys'
+    def keys(limit: nil, offset: nil)
+      body = { limit: limit, offset: offset }.compact
+
+      http_get '/keys', body
     end
 
     def key(key_uid)

--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -58,8 +58,8 @@ module MeiliSearch
       http_get '/keys', body
     end
 
-    def key(key_uid)
-      http_get "/keys/#{key_uid}"
+    def key(uid_or_key)
+      http_get "/keys/#{uid_or_key}"
     end
 
     def create_key(key_options)
@@ -68,15 +68,15 @@ module MeiliSearch
       http_post '/keys', body
     end
 
-    def update_key(key_uid, key_options)
+    def update_key(uid_or_key, key_options)
       body = Utils.transform_attributes(key_options)
       body = body.slice('description', 'name')
 
-      http_patch "/keys/#{key_uid}", body
+      http_patch "/keys/#{uid_or_key}", body
     end
 
-    def delete_key(key_uid)
-      http_delete "/keys/#{key_uid}"
+    def delete_key(uid_or_key)
+      http_delete "/keys/#{uid_or_key}"
     end
 
     ### HEALTH

--- a/spec/meilisearch/client/keys_spec.rb
+++ b/spec/meilisearch/client/keys_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe 'MeiliSearch::Client - Keys' do
   context 'When managing keys' do
+    let(:uuid_v4) { 'c483e150-cff1-4a45-ac26-bb8eb8e01d36' }
     let(:delete_docs_key_options) do
       {
         description: 'A new key to delete docs',
@@ -30,10 +31,12 @@ RSpec.describe 'MeiliSearch::Client - Keys' do
       expect(new_key['description']).to eq('A new key to add docs')
     end
 
-    it 'creates a key using snake_case' do
-      new_key = client.create_key(add_docs_key_options)
+    it 'creates a key with setting uid' do
+      new_key = client.create_key(add_docs_key_options.merge(uid: uuid_v4))
 
       expect(new_key['expiresAt']).to be_nil
+      expect(new_key['name']).to be_nil
+      expect(new_key['uid']).to eq(uuid_v4)
       expect(new_key['key']).to be_a(String)
       expect(new_key['createdAt']).to be_a(String)
       expect(new_key['updatedAt']).to be_a(String)
@@ -41,7 +44,7 @@ RSpec.describe 'MeiliSearch::Client - Keys' do
       expect(new_key['description']).to eq('A new key to add docs')
     end
 
-    it 'gets a key' do
+    it 'gets a key with their key data' do
       new_key = client.create_key(delete_docs_key_options)
 
       expect(client.key(new_key['key'])['description']).to eq('A new key to delete docs')
@@ -56,7 +59,32 @@ RSpec.describe 'MeiliSearch::Client - Keys' do
       expect(key['description']).to eq('A new key to delete docs')
     end
 
-    it 'updates a key' do
+    it 'retrieves a list of keys' do
+      new_key = client.create_key(add_docs_key_options)
+
+      list = client.keys
+
+      expect(list.keys).to contain_exactly('limit', 'offset', 'results', 'total')
+      expect(list['results']).to eq([new_key])
+      expect(list['total']).to eq(1)
+    end
+
+    it 'paginates keys list with limit/offset' do
+      client.create_key(add_docs_key_options)
+
+      expect(client.keys(limit: 0, offset: 20)['results']).to be_empty
+      expect(client.keys(limit: 5, offset: 199)['results']).to be_empty
+    end
+
+    it 'gets a key with their uid' do
+      new_key = client.create_key(delete_docs_key_options.merge(uid: uuid_v4))
+
+      key = client.key(uuid_v4)
+
+      expect(key).to eq(new_key)
+    end
+
+    it 'updates a key with their key data' do
       new_key = client.create_key(delete_docs_key_options)
       new_updated_key = client.update_key(new_key['key'], indexes: ['coco'], description: 'no coco')
 
@@ -66,20 +94,20 @@ RSpec.describe 'MeiliSearch::Client - Keys' do
       expect(new_updated_key['indexes']).to eq(['*'])
     end
 
-    it 'updates a key using snake_case' do
-      new_key = client.create_key(delete_docs_key_options)
-      new_updated_key = client.update_key(new_key['key'], indexes: ['coco'])
+    it 'updates a key with their uid data' do
+      new_key = client.create_key(delete_docs_key_options.merge(uid: uuid_v4))
+      new_updated_key = client.update_key(uuid_v4, name: 'coco')
 
-      expect(new_updated_key['key']).to eq(new_key['key'])
-      expect(new_updated_key['description']).to eq(new_key['description'])
-      expect(new_updated_key['indexes']).to eq(['*'])
+      expect(new_updated_key['name']).to eq('coco')
     end
 
     it 'deletes a key' do
       new_key = client.create_key(add_docs_key_options)
       client.delete_key(new_key['key'])
 
-      expect(client.keys.filter { |k| k['key'] == new_key['key'] }).to be_empty
+      expect {
+        client.key(new_key['key'])
+      }.to raise_error(MeiliSearch::ApiError)
     end
   end
 end


### PR DESCRIPTION
- Add options to `client.keys(limit:, offset:)` `limit` and `offset` to allow paginate the results.
- Use a better name in the arguments list in the `create_key`, `update_key` and `delete_key`: `uid_or_key` instead of just `key_uid` because now is possible to use both of them.