### PR TITLE
Indexes and Documents changes v2

### DIFF
--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -4,12 +4,10 @@ module MeiliSearch
   class Client < HTTPRequest
     include MeiliSearch::TenantToken
 
-    ALLOWED_PARAMS = [:limit, :offset].freeze
-
     ### INDEXES
 
     def raw_indexes(options = {})
-      body = Utils.transform_attributes(options.transform_keys(&:to_sym).slice(*ALLOWED_PARAMS))
+      body = Utils.transform_attributes(options.transform_keys(&:to_sym).slice(:limit, :offset))
 
       http_get('/indexes', body)
     end

--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -4,16 +4,24 @@ module MeiliSearch
   class Client < HTTPRequest
     include MeiliSearch::TenantToken
 
+    ALLOWED_PARAMS = [:limit, :offset].freeze
+
     ### INDEXES
 
-    def raw_indexes
-      http_get('/indexes')
+    def raw_indexes(options = {})
+      body = Utils.transform_attributes(options.transform_keys(&:to_sym).slice(*ALLOWED_PARAMS))
+
+      http_get('/indexes', body)
     end
 
-    def indexes
-      raw_indexes['results'].map do |index_hash|
+    def indexes(options = {})
+      response = raw_indexes(options)
+
+      response['results'].map! do |index_hash|
         index_object(index_hash['uid'], index_hash['primaryKey'])
       end
+
+      response
     end
 
     # Usage:

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -54,9 +54,11 @@ module MeiliSearch
 
     ### DOCUMENTS
 
-    def document(document_id)
+    def document(document_id, fields: nil)
       encode_document = URI.encode_www_form_component(document_id)
-      http_get "/indexes/#{@uid}/documents/#{encode_document}"
+      body = { fields: fields&.join(',') }.compact
+
+      http_get("/indexes/#{@uid}/documents/#{encode_document}", body)
     end
     alias get_document document
     alias get_one_document document

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -62,7 +62,10 @@ module MeiliSearch
     alias get_one_document document
 
     def documents(options = {})
-      http_get "/indexes/#{@uid}/documents", Utils.transform_attributes(options)
+      body = Utils.transform_attributes(options.transform_keys(&:to_sym).slice(:limit, :offset, :fields))
+      body = body.transform_values { |v| v.respond_to?(:join) ? v.join(',') : v }
+
+      http_get "/indexes/#{@uid}/documents", body
     end
     alias get_documents documents
 

--- a/spec/meilisearch/client/indexes_spec.rb
+++ b/spec/meilisearch/client/indexes_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     it 'returns MeiliSearch::Index objects' do
       client.create_index!('index')
 
-      index = client.indexes.first
+      index = client.indexes['results'].first
 
       expect(index).to be_a(MeiliSearch::Index)
     end
@@ -128,12 +128,24 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
     it 'gets a list of indexes' do
       ['first_index', 'second_index', 'third_index'].each { |name| client.create_index!(name) }
 
-      indexes = client.indexes
+      indexes = client.indexes['results']
 
       expect(indexes).to be_a(Array)
       expect(indexes.length).to eq(3)
       uids = indexes.map(&:uid)
       expect(uids).to contain_exactly('first_index', 'second_index', 'third_index')
+    end
+
+    it 'paginates indexes list with limit and offset' do
+      ['first_index', 'second_index', 'third_index'].each { |name| client.create_index!(name) }
+
+      indexes = client.indexes(limit: 1, offset: 2)
+
+      expect(indexes['results']).to be_a(Array)
+      expect(indexes['total']).to eq(3)
+      expect(indexes['limit']).to eq(1)
+      expect(indexes['offset']).to eq(2)
+      expect(indexes['results'].map(&:uid)).to eq(['third_index'])
     end
   end
 

--- a/spec/meilisearch/index/documents_spec.rb
+++ b/spec/meilisearch/index/documents_spec.rb
@@ -117,6 +117,14 @@ CSV
         expect(task.keys).to eq(['objectId', 'title', 'comment'])
       end
 
+      it 'slices response fields' do
+        index.add_documents!(documents)
+
+        task = index.document(1, fields: ['title'])
+
+        expect(task.keys).to eq(['title'])
+      end
+
       it 'infers primary-key attribute' do
         index.add_documents!(documents)
         expect(index.fetch_primary_key).to eq('objectId')

--- a/spec/meilisearch/index/documents_spec.rb
+++ b/spec/meilisearch/index/documents_spec.rb
@@ -196,6 +196,13 @@ CSV
         expect(docs.size).to eq(5)
         expect(docs.first['objectId']).to eq(index.documents['results'][2]['objectId'])
       end
+
+      it 'browses documents with fields' do
+        docs = index.documents(fields: ['title'])['results']
+
+        expect(docs).to be_a(Array)
+        expect(docs.first.keys).to eq(['title'])
+      end
     end
 
     describe 'updating documents' do

--- a/spec/support/indexes_helpers.rb
+++ b/spec/support/indexes_helpers.rb
@@ -3,7 +3,7 @@
 module IndexesHelpers
   def clear_all_indexes(client)
     indexes = client.indexes
-    uids = indexes.map(&:uid)
+    uids = indexes['results'].map(&:uid)
     uids.each do |uid|
       client.delete_index(uid)
     end


### PR DESCRIPTION
- Add support to paginate the indexes list with `limit`, `offset`.
- Add support to `limit`, `offset`, `fields` in the documents.