### PR TITLE
Update version for the next release (v0.19.0)

### DIFF
--- a/lib/meilisearch/version.rb
+++ b/lib/meilisearch/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module MeiliSearch
-  VERSION = '0.18.3'
+  VERSION = '0.19.0'
 
   def self.qualified_version
     "Meilisearch Ruby (v#{VERSION})"


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.28.0 :tada:
Check out the changelog of [Meilisearch v0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0) for more information on the changes.

## 💥  Breaking Changes

- `MeiliSearch::Client#keys` now returns a hash with: (#340) @brunoocasali
  - `results` array
  - `limit` integer
  - `offset` integer
  - `total` integer
- `MeiliSearch::Index#indexes`, `MeiliSearch::Client#raw_indexes` now returns a hash with: (#342) @brunoocasali
  - `results` array
  - `limit` integer
  - `offset` integer
  - `total` integer
- `MeiliSearch::Client#create_dump` now responds with a `Task` object. (#335) @brunoocasali
- `MeiliSearch::Client#get_dump_status` was removed. Use the `MeiliSearch::Client#tasks` or `MeiliSearch::Client#task` instead. (#335) @brunoocasali
- `MeiliSearch::Index#search`: (#331) @curquiza
  - Renamed `nbHits` response parameter to `estimatedTotalHits`.
  - Deleted `exhaustiveNbHits` response parameter.
  - Deleted `exhaustiveFacetsCount` response parameter.
  - `_matchesInfo` response parameter is renamed `_matchesPosition`.
  - `facetsDistribution` response parameter is renamed `facetDistribution`.
  - `facetsDistribution` request parameter is renamed `facets`.
  - `matches` request parameter is renamed `showMatchesPosition`.
- `MeiliSearch::Index#documents` now returns an hash with: (#342) @brunoocasali
  - `results` array
  - `limit` integer
  - `offset` integer
  - `total` integer
- `MeiliSearch::Index#tasks` now returns a hash with: (#336), (#341) @brunoocasali
  - `results` array
  - `limit` integer
  - `from` integer
  - `next` integer
- `add_documents`, `create_dump`, `update_settings` and other methods that "creates" a new task, now responds with a `taskUid` instead of `uid` (#336), (#341) @brunoocasali
- `MeiliSearch::Client#generate_tenant_token(uid, search_rules, api_key: api_key, expires_at: expires_at)` now requires a `api key uid` to generate tenant tokens. (#340) @brunoocasali

## 🐛 Enhancements

- `MeiliSearch::Client#indexes`, `MeiliSearch::Client#raw_indexes` now accepts an hash with pagination `limit`, `offset`.
- `MeiliSearch::Client#documents`, now accepts an hash with pagination `limit`, `offset`. (#342) @brunoocasali
- `MeiliSearch::Client#document`, now accepts a named param called `fields` which takes an array of strings to remap the response. (#342) @brunoocasali
- `MeiliSearch::Client#tasks`, now accepts these filtering parameters: `type`, `status` and `index_uid`. Usage example: `tasks(status: ['processing'], type: ['documentAdditionOrUpdate'])`. (#336), (#341) @brunoocasali
- `MeiliSearch::Client#create_key`, `MeiliSearch::Client#delete_key`, `MeiliSearch::Client#update_key` accepts both `api key` or `api key uid`. (#340) @brunoocasali
- `MeiliSearch::Client#create_key` can optionally specify a `uid:` to generate deterministic API keys. (#340) @brunoocasali
- `MeiliSearch::Client#update_key` only accepts `description` and `name`, other keys will be removed silently. (#340) @brunoocasali

Thanks again to @brunoocasali, @curquiza! 🎉
