### PR TITLE
Add tests to wildcarded action keys

### DIFF
--- a/spec/meilisearch/client/keys_spec.rb
+++ b/spec/meilisearch/client/keys_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe 'MeiliSearch::Client - Keys' do
       expect(new_key['description']).to eq('A new key to add docs')
     end
 
+    it 'creates a key with wildcarded action' do
+      new_key = client.create_key(add_docs_key_options.merge(actions: ['documents.*']))
+
+      expect(new_key['actions']).to eq(['documents.*'])
+    end
+
     it 'creates a key with setting uid' do
       new_key = client.create_key(add_docs_key_options.merge(uid: uuid_v4))
 


### PR DESCRIPTION
Ensure support to keys with wildcarded actions.

- `actions` field during key creation now accepts wildcards on actions. For example, `indexes.*` provides rights to `indexes.create`, `indexes.get`,`indexes.delete`, `indexes.delete`, and `indexes.update`.