### PR TITLE
Add update filter for tasks

### DIFF
--- a/lib/meilisearch/task.rb
+++ b/lib/meilisearch/task.rb
@@ -5,7 +5,7 @@ require 'timeout'
 
 module MeiliSearch
   class Task < HTTPRequest
-    ALLOWED_PARAMS = [:limit, :from, :index_uid, :type, :status].freeze
+    ALLOWED_PARAMS = [:limit, :from, :index_uids, :types, :statuses].freeze
 
     def task_list(options = {})
       body = Utils.transform_attributes(options.transform_keys(&:to_sym).slice(*ALLOWED_PARAMS))
@@ -19,7 +19,7 @@ module MeiliSearch
     end
 
     def index_tasks(index_uid)
-      http_get '/tasks', { indexUid: [index_uid].flatten.join(',') }
+      http_get '/tasks', { indexUids: [index_uid].flatten.join(',') }
     end
 
     def index_task(task_uid)

--- a/lib/meilisearch/task.rb
+++ b/lib/meilisearch/task.rb
@@ -5,7 +5,11 @@ require 'timeout'
 
 module MeiliSearch
   class Task < HTTPRequest
-    ALLOWED_PARAMS = [:limit, :from, :index_uids, :types, :statuses].freeze
+    ALLOWED_PARAMS = [
+      :limit, :from, :index_uids, :types, :statuses, :uids, :canceled_by,
+      :before_enqueued_at, :after_enqueued_at, :before_started_at, :after_started_at,
+      :before_finished_at, :after_finished_at
+    ].freeze
 
     def task_list(options = {})
       body = Utils.transform_attributes(options.transform_keys(&:to_sym).slice(*ALLOWED_PARAMS))

--- a/spec/meilisearch/client/tasks_spec.rb
+++ b/spec/meilisearch/client/tasks_spec.rb
@@ -60,6 +60,25 @@ RSpec.describe 'MeiliSearch::Tasks' do
     expect(tasks['results'].count).to be > 1
   end
 
+  it 'ensures supports to all available filters' do
+    allow(MeiliSearch::Utils).to receive(:transform_attributes).and_call_original
+
+    client.tasks(
+      canceled_by: [1, 2], uids: [2], foo: 'bar',
+      before_enqueued_at: '2022-01-20', after_enqueued_at: '2022-01-20',
+      before_started_at: '2022-01-20', after_started_at: '2022-01-20',
+      before_finished_at: '2022-01-20', after_finished_at: '2022-01-20'
+    )
+
+    expect(MeiliSearch::Utils).to have_received(:transform_attributes)
+      .with(
+        canceled_by: [1, 2], uids: [2],
+        before_enqueued_at: '2022-01-20', after_enqueued_at: '2022-01-20',
+        before_started_at: '2022-01-20', after_started_at: '2022-01-20',
+        before_finished_at: '2022-01-20', after_finished_at: '2022-01-20'
+      )
+  end
+
   describe '#index.wait_for_task' do
     it 'waits for task with default values' do
       task = index.add_documents(documents)

--- a/spec/meilisearch/client/tasks_spec.rb
+++ b/spec/meilisearch/client/tasks_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe 'MeiliSearch::Tasks' do
     expect(tasks['next']).to be_a(Integer)
   end
 
-  it 'filters tasks with index_uid/type/status' do
-    tasks = client.tasks(index_uid: ['a-cool-index-name'])
+  it 'filters tasks with index_uidx/typex/statuses' do
+    tasks = client.tasks(index_uids: ['a-cool-index-name'])
 
     expect(tasks['results'].count).to eq(0)
 
-    tasks = client.tasks(index_uid: ['books'], type: ['documentAdditionOrUpdate'], status: ['succeeded'])
+    tasks = client.tasks(index_uids: ['books'], types: ['documentAdditionOrUpdate'], statuses: ['succeeded'])
 
     expect(tasks['results'].count).to be > 1
   end


### PR DESCRIPTION
### Add/Update filters for `/tasks`

Add filters for this endpoint:

- `uids` filter. e.g `/tasks?uids=1,2,3,4`
- `canceledBy` filter. e.g `/tasks?canceledBy=99,100`
- `beforeEnqueuedAt` and `afterEnqueuedAt`. e.g `/tasks?afterEnqueuedAt=2022-01-20&beforeEnqueuedAt=2022-01-23`
- `beforeStartedAt` and `afterStartedAt`. e.g `/tasks?afterStartedAt=2022-01-20&beforeStartedAt=2022-01-23`
- `beforeFinishedAt` and `afterFinishedAt`. e.g `/tasks?afterFinishedAt=2022-01-20&beforeFinishedAt=2022-01-23`

Rename filters and error codes for this endpoint:

- `indexUid` query parameter is renamed `indexUids`
- `type` query parameter is renamed `types`
- `status` query parameter is renamed `statuses`
