### PR TITLE
Add `cancel_tasks` method

### DIFF
--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -116,6 +116,10 @@ module MeiliSearch
 
     ### TASKS
 
+    def cancel_tasks(options = {})
+      task_endpoint.cancel_tasks(options)
+    end
+
     def tasks(options = {})
       task_endpoint.task_list(options)
     end

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -64,10 +64,7 @@ module MeiliSearch
     alias get_one_document document
 
     def documents(options = {})
-      body = Utils.transform_attributes(options.transform_keys(&:to_sym).slice(:limit, :offset, :fields))
-      body = body.transform_values { |v| v.respond_to?(:join) ? v.join(',') : v }
-
-      http_get "/indexes/#{@uid}/documents", body
+      http_get "/indexes/#{@uid}/documents", Utils.parse_query(options, [:limit, :offset, :fields])
     end
     alias get_documents documents
 

--- a/lib/meilisearch/task.rb
+++ b/lib/meilisearch/task.rb
@@ -12,10 +12,7 @@ module MeiliSearch
     ].freeze
 
     def task_list(options = {})
-      body = Utils.transform_attributes(options.transform_keys(&:to_sym).slice(*ALLOWED_PARAMS))
-      body = body.transform_values { |v| v.respond_to?(:join) ? v.join(',') : v }
-
-      http_get '/tasks/', body
+      http_get '/tasks/', Utils.parse_query(options, ALLOWED_PARAMS)
     end
 
     def task(task_uid)

--- a/lib/meilisearch/task.rb
+++ b/lib/meilisearch/task.rb
@@ -10,6 +10,7 @@ module MeiliSearch
       :before_enqueued_at, :after_enqueued_at, :before_started_at, :after_started_at,
       :before_finished_at, :after_finished_at
     ].freeze
+    ALLOWED_CANCELATION_PARAMS = (ALLOWED_PARAMS - [:limit, :from]).freeze
 
     def task_list(options = {})
       http_get '/tasks/', Utils.parse_query(options, ALLOWED_PARAMS)
@@ -25,6 +26,10 @@ module MeiliSearch
 
     def index_task(task_uid)
       http_get "/tasks/#{task_uid}"
+    end
+
+    def cancel_tasks(options)
+      http_post '/tasks/cancel', nil, Utils.parse_query(options, ALLOWED_CANCELATION_PARAMS)
     end
 
     def wait_for_task(task_uid, timeout_in_ms = 5000, interval_in_ms = 50)

--- a/lib/meilisearch/utils.rb
+++ b/lib/meilisearch/utils.rb
@@ -23,6 +23,16 @@ module MeiliSearch
         end
     end
 
+    def self.parse_query(original_options, allowed_params = [])
+      only_allowed_params = original_options.transform_keys(&:to_sym).slice(*allowed_params)
+
+      Utils.transform_attributes(only_allowed_params).then do |body|
+        body.transform_values do |v|
+          v.respond_to?(:join) ? v.join(',') : v
+        end
+      end
+    end
+
     private_class_method :parse
   end
 end

--- a/spec/meilisearch/client/tasks_spec.rb
+++ b/spec/meilisearch/client/tasks_spec.rb
@@ -152,4 +152,34 @@ RSpec.describe 'MeiliSearch::Tasks' do
       end.to raise_error(Timeout::Error)
     end
   end
+
+  describe '#client.cancel_tasks' do
+    it 'ensures supports to all available filters' do
+      allow(MeiliSearch::Utils).to receive(:transform_attributes).and_call_original
+
+      client.cancel_tasks(
+        canceled_by: [1, 2], uids: [2], foo: 'bar',
+        before_enqueued_at: '2022-01-20', after_enqueued_at: '2022-01-20',
+        before_started_at: '2022-01-20', after_started_at: '2022-01-20',
+        before_finished_at: '2022-01-20', after_finished_at: '2022-01-20'
+      )
+
+      expect(MeiliSearch::Utils).to have_received(:transform_attributes)
+        .with(
+          canceled_by: [1, 2], uids: [2],
+          before_enqueued_at: '2022-01-20', after_enqueued_at: '2022-01-20',
+          before_started_at: '2022-01-20', after_started_at: '2022-01-20',
+          before_finished_at: '2022-01-20', after_finished_at: '2022-01-20'
+        )
+    end
+
+    it 'has fields in the details field' do
+      task = client.cancel_tasks(uids: [1, 2])
+      task = client.wait_for_task(task['taskUid'])
+
+      expect(task['details']['originalFilters']).to eq('uids=1%2C2')
+      expect(task['details']['matchedTasks']).to be_a(Integer)
+      expect(task['details']['canceledTasks']).to be_a(Integer)
+    end
+  end
 end

--- a/spec/meilisearch/utils_spec.rb
+++ b/spec/meilisearch/utils_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe MeiliSearch::Utils do
+  describe '.parse_query' do
+    it 'transforms arrays into strings' do
+      data = described_class.parse_query({ array: [1, 2, 3], other: 'string' }, [:array, :other])
+
+      expect(data).to eq({ 'array' => '1,2,3', 'other' => 'string' })
+    end
+
+    it 'cleans list based on another list' do
+      data = described_class.parse_query({ array: [1, 2, 3], other: 'string' }, [:array, :other])
+
+      expect(data).to eq({ 'array' => '1,2,3', 'other' => 'string' })
+    end
+  end
+end


### PR DESCRIPTION
Allow users to cancel a `processing` or an `enqueued` task.

- A new endpoint: `POST /tasks/cancel`
- Guarantee all the filters available in the `GET /tasks` minus from and limit are available.
