### PR TITLE
Add `delete_tasks` method

### DIFF
--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -126,6 +126,10 @@ module MeiliSearch
       task_endpoint.cancel_tasks(options)
     end
 
+    def delete_tasks(options = {})
+      task_endpoint.delete_tasks(options)
+    end
+
     def tasks(options = {})
       task_endpoint.task_list(options)
     end

--- a/lib/meilisearch/http_request.rb
+++ b/lib/meilisearch/http_request.rb
@@ -73,11 +73,12 @@ module MeiliSearch
       )
     end
 
-    def http_delete(relative_path = '')
+    def http_delete(relative_path = '', query_params = nil)
       send_request(
         proc { |path, config| self.class.delete(path, config) },
         relative_path,
         config: {
+          query_params: query_params,
           headers: remove_headers(@headers.dup, 'Content-Type'),
           options: @options
         }

--- a/lib/meilisearch/task.rb
+++ b/lib/meilisearch/task.rb
@@ -32,6 +32,10 @@ module MeiliSearch
       http_post '/tasks/cancel', nil, Utils.parse_query(options, ALLOWED_CANCELATION_PARAMS)
     end
 
+    def delete_tasks(options)
+      http_delete '/tasks', Utils.parse_query(options, ALLOWED_CANCELATION_PARAMS)
+    end
+
     def wait_for_task(task_uid, timeout_in_ms = 5000, interval_in_ms = 50)
       Timeout.timeout(timeout_in_ms.to_f / 1000) do
         loop do

--- a/spec/meilisearch/client/tasks_spec.rb
+++ b/spec/meilisearch/client/tasks_spec.rb
@@ -177,9 +177,39 @@ RSpec.describe 'MeiliSearch::Tasks' do
       task = client.cancel_tasks(uids: [1, 2])
       task = client.wait_for_task(task['taskUid'])
 
-      expect(task['details']['originalFilters']).to eq('uids=1%2C2')
+      expect(task['details']['originalFilter']).to eq('?uids=1%2C2')
       expect(task['details']['matchedTasks']).to be_a(Integer)
       expect(task['details']['canceledTasks']).to be_a(Integer)
+    end
+  end
+
+  describe '#client.delete_tasks' do
+    it 'ensures supports to all available filters' do
+      allow(MeiliSearch::Utils).to receive(:transform_attributes).and_call_original
+
+      client.delete_tasks(
+        canceled_by: [1, 2], uids: [2], foo: 'bar',
+        before_enqueued_at: '2022-01-20', after_enqueued_at: '2022-01-20',
+        before_started_at: '2022-01-20', after_started_at: '2022-01-20',
+        before_finished_at: '2022-01-20', after_finished_at: '2022-01-20'
+      )
+
+      expect(MeiliSearch::Utils).to have_received(:transform_attributes)
+        .with(
+          canceled_by: [1, 2], uids: [2],
+          before_enqueued_at: '2022-01-20', after_enqueued_at: '2022-01-20',
+          before_started_at: '2022-01-20', after_started_at: '2022-01-20',
+          before_finished_at: '2022-01-20', after_finished_at: '2022-01-20'
+        )
+    end
+
+    it 'has fields in the details field' do
+      task = client.delete_tasks(uids: [1, 2])
+      task = client.wait_for_task(task['taskUid'])
+
+      expect(task['details']['originalFilter']).to eq('?uids=1%2C2')
+      expect(task['details']['matchedTasks']).to be_a(Integer)
+      expect(task['details']['deletedTasks']).to be_a(Integer)
     end
   end
 end


### PR DESCRIPTION
- A new endpoint: `DELETE /tasks`
- Guarantee all the filters available in the `GET /tasks` minus from and limit are available.
- Add `uids` filter. e.g `/tasks?uids=1,2,3,4` (⚠️ only effective after RC1)
  - error code in case of failure: `invalid_task_uids_filter`
- Add `canceledBy` filter. e.g `/tasks?canceledBy=99,100`
  - error code in case of failure: `invalid_task_canceled_by_filter`
- Add `beforeEnqueuedAt` and `afterEnqueuedAt`. e.g `/tasks?afterEnqueuedAt=2022-01-20&beforeEnqueuedAt=2022-01-23`
- Add `beforeStartedAt` and `afterStartedAt`. e.g `/tasks?afterStartedAt=2022-01-20&beforeStartedAt=2022-01-23`
- Add `beforeFinishedAt` and `afterFinishedAt`. e.g `/tasks?afterFinishedAt=2022-01-20&beforeFinishedAt=2022-01-23`
