### PR TITLE
Add support to finite pagination

### DIFF
--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -191,7 +191,10 @@ module MeiliSearch
       parsed_options = Utils.transform_attributes({ q: query.to_s }.merge(options.compact))
 
       response = http_post "/indexes/#{@uid}/search", parsed_options
-      response['nbHits'] ||= response['estimatedTotalHits']
+
+      if !response.key?('totalPages')
+        response['nbHits'] ||= response['estimatedTotalHits']
+      end
 
       response
     end

--- a/spec/meilisearch/index/search/q_spec.rb
+++ b/spec/meilisearch/index/search/q_spec.rb
@@ -69,4 +69,18 @@ RSpec.describe 'MeiliSearch::Index - Basic search' do
     expect(response['hits'].first['objectId']).to eq(4)
     expect(response['hits'].first).not_to have_key('_formatted')
   end
+
+  context 'with finite pagination params' do
+    it 'responds with specialized fields' do
+      response = index.search('coco', { page: 2, hits_per_page: 2 })
+
+      expect(response.keys).to contain_exactly(*FINITE_PAGINATED_SEARCH_RESPONSE_KEYS)
+    end
+
+    it 'responds with specialized fields' do
+      response = index.search('coco', { page: 2, hitsPerPage: 2 })
+
+      expect(response.keys).to contain_exactly(*FINITE_PAGINATED_SEARCH_RESPONSE_KEYS)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,16 @@ DEFAULT_SEARCH_RESPONSE_KEYS = [
   'nbHits'
 ].freeze
 
+FINITE_PAGINATED_SEARCH_RESPONSE_KEYS = [
+  'hits',
+  'query',
+  'processingTimeMs',
+  'hitsPerPage',
+  'page',
+  'totalPages',
+  'totalHits',
+].freeze
+
 Dir["#{Dir.pwd}/spec/support/**/*.rb"].sort.each { |file| require file }
 
 RSpec.configure do |config|


### PR DESCRIPTION
Add support to finite pagination.

Now you can call: 
- `Movie.search('batman', { page: 1, hits_per_page: 10 })`
- `Movie.search('batman', { hits_per_page: 10 })`
- `Movie.search('batman', { page: 4 })`

`results = Movie.search('batman', { page: 4 })`

And get a limited pagination with a fixed number of total hits in the results object `results['totalHits']`.

You can still use the `offset/limit` by calling `Movie.search('batman', { limit: 4, offset: 10 })`