### PR TITLE
Update version for the next release (v0.21.0)

### DIFF
--- a/lib/meilisearch/version.rb
+++ b/lib/meilisearch/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module MeiliSearch
-  VERSION = '0.20.0'
+  VERSION = '0.21.0'
 
   def self.qualified_version
     "Meilisearch Ruby (v#{VERSION})"


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.30.0 :tada:
Check out the changelog of [Meilisearch v0.30.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0) for more information on the changes.

## 🚀 Enhancements

- Add `MeilisearchClient#cancel_tasks` (#392) @brunoocasali 
- Add `MeilisearchClient#swap_indexes` (#393) @brunoocasali 
- Add `MeilisearchClient#delete_tasks` (#394) @brunoocasali 
- Add support to finite pagination by using `page` and `hits_per_page` like `index.search('', { page: 1, hits_per_page: 10 })`
- Add filters for tasks resources (#391) @brunoocasali 
  - `uids` filter parameter for `MeilisearchClient#get_tasks({ uids: [1, 2, 3] })`
  - `canceled_by` filter parameter for `MeilisearchClient#get_tasks({ canceled_by: [99, 100]})`
  - `before_enqueued_at` and `after_enqueued_at` filter parameter for `MeilisearchClient#get_tasks({ before_enqueued_at: DateTime.new(2022), after_enqueued_at: '2022-01-20' })`
  - `before_finished_at` and `after_finished_at` filter parameter for `MeilisearchClient#get_tasks({ before_finished_at: DateTime.new(2022), after_finished_at: '2022-01-20' })`
  - `before_started_at` and `after_started_at` filter parameter for `MeilisearchClient#get_tasks({ before_started_at: DateTime.new(2022), after_started_at: '2022-01-20' })`

## ⚠️  Breaking Changes

- Update filters for tasks resources (#391) @brunoocasali 
  - `index_uid` query parameter is renamed `index_uids` when querying `MeilisearchClient#get_tasks`
  - `type` query parameter is renamed `types` when querying `MeilisearchClient#get_tasks`
  - `status` query parameter is renamed `statuses` when querying `MeilisearchClient#get_tasks`

## 💅 Misc

* Fix broken CI after rubocop upgrade (#381) @jonatanrdsantos
* Add new code-samples for matching_strategy (#384) @thicolares
* Improve indexes names in tests (#385) @thicolares

Thanks again to @brunoocasali, @dibashthapa, @jonatanrdsantos, and @thicolares! 🎉
