### PR TITLE
Add support to receive also DateTime instances as parameters

### DIFF
--- a/lib/meilisearch/utils.rb
+++ b/lib/meilisearch/utils.rb
@@ -28,7 +28,7 @@ module MeiliSearch
 
       Utils.transform_attributes(only_allowed_params).then do |body|
         body.transform_values do |v|
-          v.respond_to?(:join) ? v.join(',') : v
+          v.respond_to?(:join) ? v.join(',') : v.to_s
         end
       end
     end

--- a/spec/meilisearch/client/tasks_spec.rb
+++ b/spec/meilisearch/client/tasks_spec.rb
@@ -185,21 +185,23 @@ RSpec.describe 'MeiliSearch::Tasks' do
 
   describe '#client.delete_tasks' do
     it 'ensures supports to all available filters' do
+      date = DateTime.new(2022, 01, 20)
+
       allow(MeiliSearch::Utils).to receive(:transform_attributes).and_call_original
 
       client.delete_tasks(
         canceled_by: [1, 2], uids: [2], foo: 'bar',
-        before_enqueued_at: '2022-01-20', after_enqueued_at: '2022-01-20',
-        before_started_at: '2022-01-20', after_started_at: '2022-01-20',
-        before_finished_at: '2022-01-20', after_finished_at: '2022-01-20'
+        before_enqueued_at: date, after_enqueued_at: date,
+        before_started_at: date, after_started_at: date,
+        before_finished_at: date, after_finished_at: date
       )
 
       expect(MeiliSearch::Utils).to have_received(:transform_attributes)
         .with(
           canceled_by: [1, 2], uids: [2],
-          before_enqueued_at: '2022-01-20', after_enqueued_at: '2022-01-20',
-          before_started_at: '2022-01-20', after_started_at: '2022-01-20',
-          before_finished_at: '2022-01-20', after_finished_at: '2022-01-20'
+          before_enqueued_at: date, after_enqueued_at: date,
+          before_started_at: date, after_started_at: date,
+          before_finished_at: date, after_finished_at: date
         )
     end
 

--- a/spec/meilisearch/utils_spec.rb
+++ b/spec/meilisearch/utils_spec.rb
@@ -9,9 +9,15 @@ RSpec.describe MeiliSearch::Utils do
     end
 
     it 'cleans list based on another list' do
-      data = described_class.parse_query({ array: [1, 2, 3], other: 'string' }, [:array, :other])
+      data = described_class.parse_query({ array: [1, 2, 3], ignore: 'string' }, [:array])
 
-      expect(data).to eq({ 'array' => '1,2,3', 'other' => 'string' })
+      expect(data).to eq({ 'array' => '1,2,3' })
+    end
+
+    it 'transforms dates into strings' do
+      data = described_class.parse_query({ date: DateTime.new(2012, 12, 21, 19, 5) }, [:date])
+
+      expect(data).to eq({ 'date' => '2012-12-21T19:05:00+00:00' })
     end
   end
 end


### PR DESCRIPTION
Allows receiving `DateTime` parameters in methods like `cancel_tasks({ date: DateTime.new(2022) })`