### PR TITLE
Update the version for the next release (v0.22.0)

### DIFF
--- a/lib/meilisearch/version.rb
+++ b/lib/meilisearch/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module MeiliSearch
-  VERSION = '0.21.1'
+  VERSION = '0.22.0'
 
   def self.qualified_version
     "Meilisearch Ruby (v#{VERSION})"


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v1.0.0 :tada:
Check out the changelog of [Meilisearch v1.0.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0) for more information on the changes.

## ⚠️  Breaking Changes

- Fails task when updating documents with a primary_key argument which already have a proper `primary_key` defined in the index (#410) @brunoocasali 
- New error codes [check the full changed list here](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0)

If you would like more potential breaks, please check the Meilisearch engine CHANGELOG.
