### PR TITLE
Jmks deprecate camel case attributes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Metrics/BlockLength:
 # Offense count: 2
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 327
+  Max: 328
 
 # Offense count: 1
 # Configuration parameters: Max, CountKeywordArgs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - bundle:/vendor/bundle
 
   meilisearch:
-    image: getmeili/meilisearch:v1.3.0
+    image: getmeili/meilisearch:latest
     ports:
       - "7700"
     environment:

--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -31,7 +31,7 @@ module MeiliSearch
 
     # Usage:
     # client.create_index('indexUID')
-    # client.create_index('indexUID', primaryKey: 'id')
+    # client.create_index('indexUID', primary_key: 'id')
     def create_index(index_uid, options = {})
       body = Utils.transform_attributes(options.merge(uid: index_uid))
 

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -223,8 +223,6 @@ module MeiliSearch
     def search(query, options = {})
       attributes = { q: query.to_s }.merge(options.compact)
 
-      Utils.warn_on_non_conforming_attribute_names(attributes)
-
       parsed_options = Utils.transform_attributes(attributes)
       response = http_post "/indexes/#{@uid}/search", parsed_options
 

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -221,8 +221,11 @@ module MeiliSearch
     ### SEARCH
 
     def search(query, options = {})
-      parsed_options = Utils.transform_attributes({ q: query.to_s }.merge(options.compact))
+      attributes = { q: query.to_s }.merge(options.compact)
 
+      Utils.warn_on_non_conforming_attribute_names(attributes)
+
+      parsed_options = Utils.transform_attributes(attributes)
       response = http_post "/indexes/#{@uid}/search", parsed_options
 
       response['nbHits'] ||= response['estimatedTotalHits'] unless response.key?('totalPages')

--- a/lib/meilisearch/utils.rb
+++ b/lib/meilisearch/utils.rb
@@ -5,12 +5,11 @@ module MeiliSearch
     SNAKE_CASE = /[^a-zA-Z0-9]+(.)/.freeze
 
     def self.transform_attributes(body)
-      warn_on_non_conforming_attribute_names(body)
-
       case body
       when Array
         body.map { |item| transform_attributes(item) }
       when Hash
+        warn_on_non_conforming_attribute_names(body)
         parse(body)
       else
         body

--- a/lib/meilisearch/utils.rb
+++ b/lib/meilisearch/utils.rb
@@ -5,6 +5,8 @@ module MeiliSearch
     SNAKE_CASE = /[^a-zA-Z0-9]+(.)/.freeze
 
     def self.transform_attributes(body)
+      warn_on_non_conforming_attribute_names(body)
+
       case body
       when Array
         body.map { |item| transform_attributes(item) }
@@ -53,8 +55,9 @@ module MeiliSearch
     end
 
     def self.warn_on_non_conforming_attribute_names(body)
-      non_snake_case = body.keys.grep_v(/^[a-z0-9_]+$/)
+      return if body.nil?
 
+      non_snake_case = body.keys.grep_v(/^[a-z0-9_]+$/)
       return if non_snake_case.empty?
 
       message = <<~MSG

--- a/lib/meilisearch/utils.rb
+++ b/lib/meilisearch/utils.rb
@@ -58,7 +58,7 @@ module MeiliSearch
       return if non_snake_case.empty?
 
       message = <<~MSG
-        Attributes will be expected to be snake_case in future versions of MeiliSearch.
+        Attributes will be expected to be snake_case in future versions of Meilisearch Ruby.
 
         Non-conforming attributes: #{non_snake_case.join(', ')}
       MSG

--- a/lib/meilisearch/utils.rb
+++ b/lib/meilisearch/utils.rb
@@ -52,6 +52,20 @@ module MeiliSearch
       raise e.class, message_builder(e.message, method_name)
     end
 
+    def self.warn_on_non_conforming_attribute_names(body)
+      non_snake_case = body.keys.grep_v(/^[a-z0-9_]+$/)
+
+      return if non_snake_case.empty?
+
+      message = <<~MSG
+        Attributes will be expected to be snake_case in future versions of MeiliSearch.
+
+        Non-conforming attributes: #{non_snake_case.join(', ')}
+      MSG
+
+      warn(message)
+    end
+
     private_class_method :parse, :message_builder
   end
 end

--- a/spec/meilisearch/client/indexes_spec.rb
+++ b/spec/meilisearch/client/indexes_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
 
     context 'with a primary key' do
       it 'creates an index' do
-        task = client.create_index('books', primaryKey: 'reference_code')
+        task = client.create_index('books', primary_key: 'reference_code')
 
         expect(task['type']).to eq('indexCreation')
 
@@ -46,7 +46,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
       end
 
       it 'creates an index synchronously' do
-        task = client.create_index!('books', primaryKey: 'reference_code')
+        task = client.create_index!('books', primary_key: 'reference_code')
 
         expect(task['type']).to eq('indexCreation')
         expect(task['status']).to eq('succeeded')
@@ -77,7 +77,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
         it 'ignores the uid option' do
           task = client.create_index(
             'books',
-            primaryKey: 'reference_code',
+            primary_key: 'reference_code',
             uid: 'publications'
           )
 
@@ -173,7 +173,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
 
   describe '#fetch_index' do
     it 'fetches index by uid' do
-      client.create_index!('books', primaryKey: 'reference_code')
+      client.create_index!('books', primary_key: 'reference_code')
 
       fetched_index = client.fetch_index('books')
 
@@ -186,7 +186,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
 
   describe '#fetch_raw_index' do
     it 'fetch a specific index raw Hash response based on uid' do
-      client.create_index!('books', primaryKey: 'reference_code')
+      client.create_index!('books', primary_key: 'reference_code')
       index = client.fetch_index('books')
       raw_response = index.fetch_raw_info
 
@@ -202,7 +202,7 @@ RSpec.describe 'MeiliSearch::Client - Indexes' do
 
   describe '#index' do
     it 'returns an index object with the provided uid' do
-      client.create_index!('books', primaryKey: 'reference_code')
+      client.create_index!('books', primary_key: 'reference_code')
       # this index is in memory, without metadata from server
       index = client.index('books')
 

--- a/spec/meilisearch/client/keys_spec.rb
+++ b/spec/meilisearch/client/keys_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'MeiliSearch::Client - Keys' do
         description: 'A new key to delete docs',
         actions: ['documents.delete'],
         indexes: ['*'],
-        expiresAt: nil
+        expires_at: nil
       }
     end
     let(:add_docs_key_options) do
@@ -16,7 +16,7 @@ RSpec.describe 'MeiliSearch::Client - Keys' do
         description: 'A new key to add docs',
         actions: ['documents.add'],
         indexes: ['*'],
-        expiresAt: nil
+        expires_at: nil
       }
     end
 

--- a/spec/meilisearch/client/requests_spec.rb
+++ b/spec/meilisearch/client/requests_spec.rb
@@ -16,12 +16,4 @@ RSpec.describe 'MeiliSearch::Client requests' do
     expect(index.uid).to eq(key)
     expect(index.primary_key).to eq(key)
   end
-
-  it 'parses options when they are in a different shape' do
-    client.create_index!(key, priMARy_kEy: key)
-
-    index = client.fetch_index(key)
-    expect(index.uid).to eq(key)
-    expect(index.primary_key).to eq(key)
-  end
 end

--- a/spec/meilisearch/index/base_spec.rb
+++ b/spec/meilisearch/index/base_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MeiliSearch::Index do
   end
 
   it 'fetch the raw Hash info of the index' do
-    client.create_index!('books', primaryKey: 'reference_number')
+    client.create_index!('books', primary_key: 'reference_number')
 
     raw_index = client.fetch_raw_index('books')
 
@@ -37,7 +37,7 @@ RSpec.describe MeiliSearch::Index do
   end
 
   it 'get primary-key of index if it exists' do
-    client.create_index!('index_with_prirmary_key', primaryKey: 'primary_key')
+    client.create_index!('index_with_prirmary_key', primary_key: 'primary_key')
 
     index = client.fetch_index('index_with_prirmary_key')
     expect(index.primary_key).to eq('primary_key')
@@ -54,7 +54,7 @@ RSpec.describe MeiliSearch::Index do
   it 'updates primary-key of index if not defined before' do
     client.create_index!('uid')
 
-    task = client.index('uid').update(primaryKey: 'new_primary_key')
+    task = client.index('uid').update(primary_key: 'new_primary_key')
     expect(task['type']).to eq('indexUpdate')
     client.wait_for_task(task['taskUid'])
 
@@ -70,9 +70,9 @@ RSpec.describe MeiliSearch::Index do
   end
 
   it 'updates primary-key of index if has been defined before but there is not docs' do
-    client.create_index!('books', primaryKey: 'reference_number')
+    client.create_index!('books', primary_key: 'reference_number')
 
-    task = client.index('books').update(primaryKey: 'international_standard_book_number')
+    task = client.index('books').update(primary_key: 'international_standard_book_number')
     expect(task['type']).to eq('indexUpdate')
     client.wait_for_task(task['taskUid'])
 
@@ -91,7 +91,7 @@ RSpec.describe MeiliSearch::Index do
     index = client.index('uid')
     index.add_documents!({ id: 1, title: 'My Title' })
 
-    task = index.update(primaryKey: 'new_primary_key')
+    task = index.update(primary_key: 'new_primary_key')
     expect(task['type']).to eq('indexUpdate')
     achieved_task = client.wait_for_task(task['taskUid'])
 
@@ -177,7 +177,7 @@ RSpec.describe MeiliSearch::Index do
   end
 
   it 'works with method aliases' do
-    client.create_index!('uid', primaryKey: 'primary_key')
+    client.create_index!('uid', primary_key: 'primary_key')
 
     index = client.fetch_index('uid')
     expect(index.method(:fetch_primary_key) == index.method(:get_primary_key)).to be_truthy

--- a/spec/meilisearch/index/search/attributes_to_crop_spec.rb
+++ b/spec/meilisearch/index/search/attributes_to_crop_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe 'MeiliSearch::Index - Cropped search' do
   before { index.add_documents!(document) }
 
   it 'searches with default cropping params' do
-    response = index.search('galaxy', attributesToCrop: ['*'], cropLength: 6)
+    response = index.search('galaxy', attributes_to_crop: ['*'], crop_length: 6)
 
     expect(response.dig('hits', 0, '_formatted', 'description')).to eq('…Guide to the Galaxy is a…')
   end
 
   it 'searches with custom crop markers' do
-    response = index.search('galaxy', attributesToCrop: ['*'], cropLength: 6, cropMarker: '(ꈍᴗꈍ)')
+    response = index.search('galaxy', attributes_to_crop: ['*'], crop_length: 6, crop_marker: '(ꈍᴗꈍ)')
 
     expect(response.dig('hits', 0, '_formatted', 'description')).to eq('(ꈍᴗꈍ)Guide to the Galaxy is a(ꈍᴗꈍ)')
   end
@@ -27,9 +27,9 @@ RSpec.describe 'MeiliSearch::Index - Cropped search' do
   it 'searches with mixed highlight and crop config' do
     response = index.search(
       'galaxy',
-      attributesToHighlight: ['*'],
-      attributesToCrop: ['*'],
-      highlightPreTag: '<span class="bold">'
+      attributes_to_highlight: ['*'],
+      attributes_to_crop: ['*'],
+      highlight_pre_tag: '<span class="bold">'
     )
 
     expect(response.dig('hits', 0, '_formatted', 'description')).to \
@@ -39,22 +39,22 @@ RSpec.describe 'MeiliSearch::Index - Cropped search' do
   it 'searches with highlight tags' do
     response = index.search(
       'galaxy',
-      attributesToHighlight: ['*'],
-      highlightPreTag: '<span>',
-      highlightPostTag: '</span>'
+      attributes_to_highlight: ['*'],
+      highlight_pre_tag: '<span>',
+      highlight_post_tag: '</span>'
     )
 
     expect(response.dig('hits', 0, '_formatted', 'description')).to include('<span>Galaxy</span>')
   end
 
   it 'does a custom search with attributes to crop' do
-    response = index.search('galaxy', { attributesToCrop: ['description'], cropLength: 6 })
+    response = index.search('galaxy', { attributes_to_crop: ['description'], crop_length: 6 })
     expect(response['hits'].first).to have_key('_formatted')
     expect(response['hits'].first['_formatted']['description']).to eq('…Guide to the Galaxy is a…')
   end
 
   it 'does a placehodler search with attributes to crop' do
-    response = index.search('', { attributesToCrop: ['description'], cropLength: 5 })
+    response = index.search('', { attributes_to_crop: ['description'], crop_length: 5 })
     expect(response['hits'].first).to have_key('_formatted')
     expect(response['hits'].first['description']).to eq(document[:description])
     expect(response['hits'].first['_formatted']['description']).to eq("The Hitchhiker's Guide to…")

--- a/spec/meilisearch/index/search/attributes_to_highlight.rb
+++ b/spec/meilisearch/index/search/attributes_to_highlight.rb
@@ -4,7 +4,7 @@ RSpec.describe 'MeiliSearch::Index - Search with highlight' do
   include_context 'search books with genre'
 
   it 'does a custom search with highlight' do
-    response = index.search('the', attributesToHighlight: ['title'])
+    response = index.search('the', attributes_to_highlight: ['title'])
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(3)
@@ -13,7 +13,7 @@ RSpec.describe 'MeiliSearch::Index - Search with highlight' do
   end
 
   it 'does a placeholder search with attributes to highlight' do
-    response = index.search('', attributesToHighlight: ['*'])
+    response = index.search('', attributes_to_highlight: ['*'])
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(7)
@@ -21,7 +21,7 @@ RSpec.describe 'MeiliSearch::Index - Search with highlight' do
   end
 
   it 'does a placeholder search (nil) with attributes to highlight' do
-    response = index.search(nil, attributesToHighlight: ['*'])
+    response = index.search(nil, attributes_to_highlight: ['*'])
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)

--- a/spec/meilisearch/index/search/attributes_to_retrieve_spec.rb
+++ b/spec/meilisearch/index/search/attributes_to_retrieve_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe 'MeiliSearch::Index - Search with attributes to retrieve' do
   include_context 'search books with genre'
 
-  it 'does a custom search with one attributesToRetrieve' do
-    response = index.search('the', attributesToRetrieve: ['title'])
+  it 'does a custom search with one attributes_to_retrieve' do
+    response = index.search('the', attributes_to_retrieve: ['title'])
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(3)
@@ -13,8 +13,8 @@ RSpec.describe 'MeiliSearch::Index - Search with attributes to retrieve' do
     expect(response['hits'].first).not_to have_key('genre')
   end
 
-  it 'does a custom search with multiple attributesToRetrieve' do
-    response = index.search('the', attributesToRetrieve: ['title', 'genre'])
+  it 'does a custom search with multiple attributes_to_retrieve' do
+    response = index.search('the', attributes_to_retrieve: ['title', 'genre'])
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(3)
@@ -23,8 +23,8 @@ RSpec.describe 'MeiliSearch::Index - Search with attributes to retrieve' do
     expect(response['hits'].first).to have_key('genre')
   end
 
-  it 'does a custom search with all attributesToRetrieve' do
-    response = index.search('the', attributesToRetrieve: ['*'])
+  it 'does a custom search with all attributes_to_retrieve' do
+    response = index.search('the', attributes_to_retrieve: ['*'])
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(3)
@@ -33,8 +33,8 @@ RSpec.describe 'MeiliSearch::Index - Search with attributes to retrieve' do
     expect(response['hits'].first).to have_key('genre')
   end
 
-  it 'does a placeholder search with one attributesToRetrieve' do
-    response = index.search('', attributesToRetrieve: ['title'])
+  it 'does a placeholder search with one attributes_to_retrieve' do
+    response = index.search('', attributes_to_retrieve: ['title'])
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)
@@ -43,8 +43,8 @@ RSpec.describe 'MeiliSearch::Index - Search with attributes to retrieve' do
     expect(response['hits'].first).not_to have_key('genre')
   end
 
-  it 'does a placeholder search with multiple attributesToRetrieve' do
-    response = index.search('', attributesToRetrieve: ['title', 'genre'])
+  it 'does a placeholder search with multiple attributes_to_retrieve' do
+    response = index.search('', attributes_to_retrieve: ['title', 'genre'])
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)
@@ -53,8 +53,8 @@ RSpec.describe 'MeiliSearch::Index - Search with attributes to retrieve' do
     expect(response['hits'].first).to have_key('genre')
   end
 
-  it 'does a placeholder search with all attributesToRetrieve' do
-    response = index.search('', attributesToRetrieve: ['*'])
+  it 'does a placeholder search with all attributes_to_retrieve' do
+    response = index.search('', attributes_to_retrieve: ['*'])
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)

--- a/spec/meilisearch/index/search/multi_params_spec.rb
+++ b/spec/meilisearch/index/search/multi_params_spec.rb
@@ -79,22 +79,4 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
     expect(response['facetDistribution']['genre']['adventure']).to eq(1)
     expect(response['facetDistribution']['genre']['fantasy']).to eq(1)
   end
-
-  context 'with snake_case options' do
-    it 'does a custom search with attributes in a unusual formatting' do
-      response = index.search(
-        'prince',
-        {
-          aTTributes_TO_Crop: ['title'],
-          crop_length: 2,
-          filter: 'genre = adventure',
-          attributes_to_highlight: ['title']
-        }
-      )
-
-      expect(response['hits'].count).to be(1)
-      expect(response['hits'].first).to have_key('_formatted')
-      expect(response['hits'].first['_formatted']['title']).to eq('…Petit <em>Prince</em>')
-    end
-  end
 end

--- a/spec/meilisearch/index/search/multi_params_spec.rb
+++ b/spec/meilisearch/index/search/multi_params_spec.rb
@@ -11,18 +11,18 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
   it 'does a custom search with attributes to crop, filter and attributes to highlight' do
     response = index.search('prince',
                             {
-                              attributesToCrop: ['title'],
-                              cropLength: 2,
+                              attributes_to_crop: ['title'],
+                              crop_length: 2,
                               filter: 'genre = adventure',
-                              attributesToHighlight: ['title']
+                              attributes_to_highlight: ['title']
                             })
     expect(response['hits'].count).to be(1)
     expect(response['hits'].first).to have_key('_formatted')
     expect(response['hits'].first['_formatted']['title']).to eq('…Petit <em>Prince</em>')
   end
 
-  it 'does a custom search with attributesToRetrieve and a limit' do
-    response = index.search('the', attributesToRetrieve: ['title', 'genre'], limit: 2)
+  it 'does a custom search with attributes_to_retrieve and a limit' do
+    response = index.search('the', attributes_to_retrieve: ['title', 'genre'], limit: 2)
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(2)
@@ -37,21 +37,21 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
   end
 
   it 'does a custom search with limit and attributes to highlight' do
-    response = index.search('the', { limit: 1, attributesToHighlight: ['*'] })
+    response = index.search('the', { limit: 1, attributes_to_highlight: ['*'] })
     expect(response).to be_a(Hash)
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(1)
     expect(response['hits'].first).to have_key('_formatted')
   end
 
-  it 'does a custom search with filter, attributesToRetrieve and attributesToHighlight' do
+  it 'does a custom search with filter, attributes_to_retrieve and attributes_to_highlight' do
     response = index.update_filterable_attributes(['genre'])
     index.wait_for_task(response['taskUid'])
     response = index.search('prinec',
                             {
                               filter: ['genre = fantasy'],
-                              attributesToRetrieve: ['title'],
-                              attributesToHighlight: ['*']
+                              attributes_to_retrieve: ['title'],
+                              attributes_to_highlight: ['*']
                             })
     expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['estimatedTotalHits']).to eq(1)
@@ -86,7 +86,7 @@ RSpec.describe 'MeiliSearch::Index - Multi-paramaters search' do
         'prince',
         {
           aTTributes_TO_Crop: ['title'],
-          cropLength: 2,
+          crop_length: 2,
           filter: 'genre = adventure',
           attributes_to_highlight: ['title']
         }

--- a/spec/meilisearch/index/settings_spec.rb
+++ b/spec/meilisearch/index/settings_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
 
     it 'updates multiples settings at the same time' do
       task = index.update_settings(
-        rankingRules: ['title:asc', 'typo'],
-        distinctAttribute: 'title'
+        ranking_rules: ['title:asc', 'typo'],
+        distinct_attribute: 'title'
       )
 
       expect(task['type']).to eq('settingsUpdate')
@@ -66,7 +66,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     end
 
     it 'updates one setting without reset the others' do
-      task = index.update_settings(stopWords: ['the'])
+      task = index.update_settings(stop_words: ['the'])
 
       expect(task['type']).to eq('settingsUpdate')
       client.wait_for_task(task['taskUid'])
@@ -79,9 +79,9 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
 
     it 'resets all settings' do
       task = index.update_settings(
-        rankingRules: ['title:asc', 'typo'],
-        distinctAttribute: 'title',
-        stopWords: ['the', 'a'],
+        ranking_rules: ['title:asc', 'typo'],
+        distinct_attribute: 'title',
+        stop_words: ['the', 'a'],
         synonyms: { wow: ['world of warcraft'] }
       )
       client.wait_for_task(task['taskUid'])
@@ -552,7 +552,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
   context 'Index with primary-key' do
     let(:index) { client.index(uid) }
 
-    before { client.create_index!(uid, primaryKey: 'id') }
+    before { client.create_index!(uid, primary_key: 'id') }
 
     it 'gets the default values of settings' do
       settings = index.settings
@@ -568,8 +568,8 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
 
     it 'updates multiples settings at the same time' do
       task = index.update_settings(
-        rankingRules: ['title:asc', 'typo'],
-        distinctAttribute: 'title'
+        ranking_rules: ['title:asc', 'typo'],
+        distinct_attribute: 'title'
       )
 
       expect(task['type']).to eq('settingsUpdate')
@@ -581,7 +581,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     end
 
     it 'updates one setting without reset the others' do
-      task = index.update_settings(stopWords: ['the'])
+      task = index.update_settings(stop_words: ['the'])
 
       expect(task['type']).to eq('settingsUpdate')
       client.wait_for_task(task['taskUid'])
@@ -594,9 +594,9 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
 
     it 'resets all settings' do
       task = index.update_settings(
-        rankingRules: ['title:asc', 'typo'],
-        distinctAttribute: 'title',
-        stopWords: ['the'],
+        ranking_rules: ['title:asc', 'typo'],
+        distinct_attribute: 'title',
+        stop_words: ['the'],
         synonyms: {
           wow: ['world of warcraft']
         }
@@ -739,12 +739,12 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     let(:new_typo_tolerance) do
       {
         'enabled' => true,
-        'minWordSizeForTypos' => {
+        'min_word_size_for_typos' => {
           'oneTypo' => 6,
           'twoTypos' => 10
         },
-        'disableOnWords' => [],
-        'disableOnAttributes' => ['title']
+        'disable_on_words' => [],
+        'disable_on_attributes' => ['title']
       }
     end
 
@@ -760,7 +760,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       update_task = index.update_typo_tolerance(new_typo_tolerance)
       client.wait_for_task(update_task['taskUid'])
 
-      expect(index.typo_tolerance).to eq(new_typo_tolerance)
+      expect(index.typo_tolerance).to eq(MeiliSearch::Utils.transform_attributes(new_typo_tolerance))
     end
 
     it 'resets typo tolerance settings' do
@@ -776,7 +776,6 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
 
   context 'On faceting' do
     let(:index) { client.index(uid) }
-    let(:faceting) { { maxValuesPerFacet: 333, sortFacetValuesBy: { '*' => 'alpha' } } }
     let(:default_faceting) { { maxValuesPerFacet: 100, sortFacetValuesBy: { '*' => 'alpha' } } }
 
     before { client.create_index!(uid) }
@@ -788,14 +787,14 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     end
 
     it 'updates faceting' do
-      update_task = index.update_faceting(faceting)
+      update_task = index.update_faceting({ 'max_values_per_facet' => 333 })
       client.wait_for_task(update_task['taskUid'])
 
-      expect(index.faceting.transform_keys(&:to_sym)).to eq(faceting)
+      expect(index.faceting).to eq({ 'maxValuesPerFacet' => 333 })
     end
 
     it 'updates faceting at null' do
-      update_task = index.update_faceting(faceting)
+      update_task = index.update_faceting({ 'max_values_per_facet' => 444 })
       client.wait_for_task(update_task['taskUid'])
 
       update_task = index.update_faceting(nil)
@@ -805,7 +804,7 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
     end
 
     it 'resets faceting' do
-      update_task = index.update_faceting(faceting)
+      update_task = index.update_faceting({ 'max_values_per_facet' => 444 })
       client.wait_for_task(update_task['taskUid'])
 
       reset_task = index.reset_faceting

--- a/spec/meilisearch/index/settings_spec.rb
+++ b/spec/meilisearch/index/settings_spec.rb
@@ -97,23 +97,6 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       expect(settings['stopWords']).to be_empty
       expect(settings['synonyms']).to be_empty
     end
-
-    context 'with snake_case options' do
-      it 'does the request with camelCase attributes' do
-        task = index.update_settings(
-          ranking_rules: ['typo'],
-          distinct_ATTribute: 'title',
-          stopWords: ['a']
-        )
-
-        client.wait_for_task(task['taskUid'])
-        settings = index.settings
-
-        expect(settings['rankingRules']).to eq(['typo'])
-        expect(settings['distinctAttribute']).to eq('title')
-        expect(settings['stopWords']).to eq(['a'])
-      end
-    end
   end
 
   context 'On ranking-rules sub-routes' do

--- a/spec/meilisearch/index/settings_spec.rb
+++ b/spec/meilisearch/index/settings_spec.rb
@@ -773,7 +773,8 @@ RSpec.describe 'MeiliSearch::Index - Settings' do
       update_task = index.update_faceting({ 'max_values_per_facet' => 333 })
       client.wait_for_task(update_task['taskUid'])
 
-      expect(index.faceting).to eq({ 'maxValuesPerFacet' => 333 })
+      expect(index.faceting['maxValuesPerFacet']).to eq(333)
+      expect(index.faceting.transform_keys(&:to_sym).keys).to include(*default_faceting.keys)
     end
 
     it 'updates faceting at null' do

--- a/spec/meilisearch/utils_spec.rb
+++ b/spec/meilisearch/utils_spec.rb
@@ -71,5 +71,31 @@ RSpec.describe MeiliSearch::Utils do
         end
       end.to raise_error(MeiliSearch::CommunicationError, /that `my_method` call requires/)
     end
+
+    describe '.warn_on_non_conforming_attribute_names' do
+      it 'warns when using camelCase attributes' do
+        attrs = { attributesToHighlight: ['field'] }
+
+        expect do
+          Utils.warn_on_non_conforming_attribute_names(attrs)
+        end.to output(include('Attributes will be expected to be snake_case', 'attributesToHighlight')).to_stderr
+      end
+
+      it 'warns when using a mixed case' do
+        attrs = { distinct_ATTribute: 'title' }
+
+        expect do
+          Utils.warn_on_non_conforming_attribute_names(attrs)
+        end.to output(include('Attributes will be expected to be snake_case', 'distinct_ATTribute')).to_stderr
+      end
+
+      it 'does not warn when using snake_case' do
+        attrs = { q: 'query', attributes_to_highlight: ['field'] }
+
+        expect do
+          Utils.warn_on_non_conforming_attribute_names(attrs)
+        end.not_to output.to_stderr
+      end
+    end
   end
 end

--- a/spec/meilisearch/utils_spec.rb
+++ b/spec/meilisearch/utils_spec.rb
@@ -45,12 +45,31 @@ RSpec.describe MeiliSearch::Utils do
         ]
       )
     end
+
+    it 'warns when using camelCase' do
+      attrs = { distinctAttribute: 'title' }
+
+      expect do
+        described_class.transform_attributes(attrs)
+      end.to output(include('Attributes will be expected to be snake_case', 'distinctAttribute')).to_stderr
+    end
+
+    it 'warns when using camelCase in an array' do
+      attrs = [
+        { 'index_uid' => 'movies', 'q' => 'prince' },
+        { 'indexUid' => 'books', 'q' => 'prince' }
+      ]
+
+      expect do
+        described_class.transform_attributes(attrs)
+      end.to output(include('Attributes will be expected to be snake_case', 'indexUid')).to_stderr
+    end
   end
 
   describe '.version_error_handler' do
     it 'spawns same error message' do
       expect do
-        MeiliSearch::Utils.version_error_handler(:my_method) do
+        described_class.version_error_handler(:my_method) do
           raise MeiliSearch::ApiError.new(405, 'I came from Meili server', {})
         end
       end.to raise_error(MeiliSearch::ApiError, /I came from Meili server/)
@@ -58,7 +77,7 @@ RSpec.describe MeiliSearch::Utils do
 
     it 'spawns message with version hint' do
       expect do
-        MeiliSearch::Utils.version_error_handler(:my_method) do
+        described_class.version_error_handler(:my_method) do
           raise MeiliSearch::ApiError.new(405, 'I came from Meili server', {})
         end
       end.to raise_error(MeiliSearch::ApiError, /that `my_method` call requires/)
@@ -66,7 +85,7 @@ RSpec.describe MeiliSearch::Utils do
 
     it 'adds hints to all error types' do
       expect do
-        MeiliSearch::Utils.version_error_handler(:my_method) do
+        described_class.version_error_handler(:my_method) do
           raise MeiliSearch::CommunicationError, 'I am an error'
         end
       end.to raise_error(MeiliSearch::CommunicationError, /that `my_method` call requires/)
@@ -77,7 +96,7 @@ RSpec.describe MeiliSearch::Utils do
         attrs = { attributesToHighlight: ['field'] }
 
         expect do
-          Utils.warn_on_non_conforming_attribute_names(attrs)
+          described_class.warn_on_non_conforming_attribute_names(attrs)
         end.to output(include('Attributes will be expected to be snake_case', 'attributesToHighlight')).to_stderr
       end
 
@@ -85,7 +104,7 @@ RSpec.describe MeiliSearch::Utils do
         attrs = { distinct_ATTribute: 'title' }
 
         expect do
-          Utils.warn_on_non_conforming_attribute_names(attrs)
+          described_class.warn_on_non_conforming_attribute_names(attrs)
         end.to output(include('Attributes will be expected to be snake_case', 'distinct_ATTribute')).to_stderr
       end
 
@@ -93,7 +112,7 @@ RSpec.describe MeiliSearch::Utils do
         attrs = { q: 'query', attributes_to_highlight: ['field'] }
 
         expect do
-          Utils.warn_on_non_conforming_attribute_names(attrs)
+          described_class.warn_on_non_conforming_attribute_names(attrs)
         end.not_to output.to_stderr
       end
     end


### PR DESCRIPTION
Following up on this branch: https://github.com/meilisearch/meilisearch-ruby/pull/377

I've updated the code to fix the conflicts and ensure the code is working.