### PR TITLE
Add Define fields to search on at search-time

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -335,6 +335,12 @@ search_parameter_guide_matching_strategy_2: |-
   client.index('movies').search('big fat liar', {
     matching_strategy: 'all'
   })
+search_parameter_guide_attributes_to_search_on_1: |-
+  POST 'http://localhost:7700/indexes/movies/search' 
+  with data: { 
+    "q": "adventure", "attributesToSearchOn": ["overview"] 
+  }
+
 add_movies_json_1: |-
   require 'json'
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,35 @@ JSON output:
   "offset": 0,
   "processingTimeMs": 0
 }
+
+
 ```
+
+#### Custom Search With attributes on at search time  <!-- omit in toc -->
+
+[Customize attributes to search on at search time](https://www.meilisearch.com/docs/reference/api/search#customize-attributes-to-search-on-at-search-time)).Available ONLY with Meilisearch v1.3 and newer (optional). 
+
+
+you can perform the search :
+
+```ruby
+index.search('wonder', { attributes_to_search_on: ['genres'] })
+```
+
+JSON output:
+
+```json
+{
+  "hits":[],
+  "query":"wonder",
+  "processingTimeMs":0,
+  "limit":20,
+  "offset":0,
+  "estimatedTotalHits":0,
+  "nbHits":0
+}
+```
+
 
 ## 🤖 Compatibility with Meilisearch
 

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -219,7 +219,8 @@ module MeiliSearch
     end
 
     ### SEARCH
-
+    # option: 
+    # attributes_to_search_on: Customize attributes to search on at search time. Available ONLY with Meilisearch v1.3 and newer (optional).
     def search(query, options = {})
       parsed_options = Utils.transform_attributes({ q: query.to_s }.merge(options.compact))
 

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -219,7 +219,7 @@ module MeiliSearch
     end
 
     ### SEARCH
-    # option: 
+    # option:
     # attributes_to_search_on: Customize attributes to search on at search time. Available ONLY with Meilisearch v1.3 and newer (optional).
     def search(query, options = {})
       parsed_options = Utils.transform_attributes({ q: query.to_s }.merge(options.compact))

--- a/spec/meilisearch/index/search/q_spec.rb
+++ b/spec/meilisearch/index/search/q_spec.rb
@@ -85,41 +85,39 @@ RSpec.describe 'MeiliSearch::Index - Basic search' do
   end
 
   context 'with attributes_to_search_on params' do
-    it 'responds with empty attributes_to_search_on' do 
-      response = index.search('prince', {attributes_to_search_on: []})
+    it 'responds with empty attributes_to_search_on' do
+      response = index.search('prince', { attributes_to_search_on: [] })
       expect(response).to be_a(Hash)
       expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
       expect(response['hits']).to be_empty
     end
 
     it 'responds with nil attributes_to_search_on' do
-      response = index.search('prince', {attributes_to_search_on: nil})
+      response = index.search('prince', { attributes_to_search_on: nil })
       expect(response).to be_a(Hash)
       expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
       expect(response['hits']).not_to be_empty
     end
 
     it 'responds with title attributes_to_search_on' do
-      response = index.search('prince', {attributes_to_search_on: ['title']})
+      response = index.search('prince', { attributes_to_search_on: ['title'] })
       expect(response).to be_a(Hash)
       expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
       expect(response['hits']).not_to be_empty
     end
 
     it 'responds with genre attributes_to_search_on' do
-      response = index.search('prince', {attributes_to_search_on: ['genry']})
+      response = index.search('prince', { attributes_to_search_on: ['genry'] })
       expect(response).to be_a(Hash)
       expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
       expect(response['hits']).to be_empty
     end
 
     it 'responds with nil attributes_to_search_on and empty query' do
-      response = index.search('', {attributes_to_search_on: nil})
+      response = index.search('', { attributes_to_search_on: nil })
       expect(response).to be_a(Hash)
       expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
       expect(response['hits'].count).to eq(documents.count)
     end
-
-
   end
 end

--- a/spec/meilisearch/index/search/q_spec.rb
+++ b/spec/meilisearch/index/search/q_spec.rb
@@ -83,4 +83,43 @@ RSpec.describe 'MeiliSearch::Index - Basic search' do
       expect(response.keys).to contain_exactly(*FINITE_PAGINATED_SEARCH_RESPONSE_KEYS)
     end
   end
+
+  context 'with attributes_to_search_on params' do
+    it 'responds with empty attributes_to_search_on' do 
+      response = index.search('prince', {attributes_to_search_on: []})
+      expect(response).to be_a(Hash)
+      expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+      expect(response['hits']).to be_empty
+    end
+
+    it 'responds with nil attributes_to_search_on' do
+      response = index.search('prince', {attributes_to_search_on: nil})
+      expect(response).to be_a(Hash)
+      expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+      expect(response['hits']).not_to be_empty
+    end
+
+    it 'responds with title attributes_to_search_on' do
+      response = index.search('prince', {attributes_to_search_on: ['title']})
+      expect(response).to be_a(Hash)
+      expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+      expect(response['hits']).not_to be_empty
+    end
+
+    it 'responds with genre attributes_to_search_on' do
+      response = index.search('prince', {attributes_to_search_on: ['genry']})
+      expect(response).to be_a(Hash)
+      expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+      expect(response['hits']).to be_empty
+    end
+
+    it 'responds with nil attributes_to_search_on and empty query' do
+      response = index.search('', {attributes_to_search_on: nil})
+      expect(response).to be_a(Hash)
+      expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+      expect(response['hits'].count).to eq(documents.count)
+    end
+
+
+  end
 end


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #458 

## What does this PR do?
- Add the ability to receive a new param in the search method called attributesToSearchOn.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
