### PR TITLE
Create a way to disable codecoverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,12 +19,15 @@
 # NOTE: If SimpleCov starts after your application code is already loaded (via require),
 # it won't be able to track your files and their coverage!
 # The SimpleCov.start must be issued before any of your application code is required!
-require 'simplecov'
-require 'codecov'
 
-SimpleCov.start do
-  add_filter %r{^/spec/}
-  formatter SimpleCov::Formatter::Codecov if ENV['CI']
+unless ENV.fetch('DISABLE_COVERAGE', false)
+  require 'simplecov'
+  require 'codecov'
+
+  SimpleCov.start do
+    add_filter %r{^/spec/}
+    formatter SimpleCov::Formatter::Codecov if ENV['CI']
+  end
 end
 
 require 'meilisearch'


### PR DESCRIPTION
No issue related, just enable a way to disable coverage, so this https://github.com/meilisearch/meilisearch/actions/workflows/sdks-tests.yml flow will not break.
