### PR TITLE
Fix error propagating logic

### DIFF
--- a/spec/meilisearch/utils_spec.rb
+++ b/spec/meilisearch/utils_spec.rb
@@ -82,6 +82,14 @@ RSpec.describe MeiliSearch::Utils do
       end.to raise_error(MeiliSearch::ApiError, /I came from Meili server/)
     end
 
+    it 'spawns same error message with html body' do
+      expect do
+        described_class.version_error_handler(:my_method) do
+          raise MeiliSearch::ApiError.new(405, 'I came from Meili server', '<html><h1>405 Error</h1></html>')
+        end
+      end.to raise_error(MeiliSearch::ApiError, /I came from Meili server/)
+    end
+
     it 'spawns same error message with no body' do
       expect do
         described_class.version_error_handler(:my_method) do

--- a/spec/meilisearch/utils_spec.rb
+++ b/spec/meilisearch/utils_spec.rb
@@ -67,10 +67,25 @@ RSpec.describe MeiliSearch::Utils do
   end
 
   describe '.version_error_handler' do
+    let(:http_body) do
+      { 'message' => 'Was expecting an operation',
+        'code' => 'invalid_document_filter',
+        'type' => 'invalid_request',
+        'link' => 'https://docs.meilisearch.com/errors#invalid_document_filter' }
+    end
+
     it 'spawns same error message' do
       expect do
         described_class.version_error_handler(:my_method) do
-          raise MeiliSearch::ApiError.new(405, 'I came from Meili server', {})
+          raise MeiliSearch::ApiError.new(405, 'I came from Meili server', http_body)
+        end
+      end.to raise_error(MeiliSearch::ApiError, /I came from Meili server/)
+    end
+
+    it 'spawns same error message with no body' do
+      expect do
+        described_class.version_error_handler(:my_method) do
+          raise MeiliSearch::ApiError.new(405, 'I came from Meili server', nil)
         end
       end.to raise_error(MeiliSearch::ApiError, /I came from Meili server/)
     end
@@ -78,7 +93,7 @@ RSpec.describe MeiliSearch::Utils do
     it 'spawns message with version hint' do
       expect do
         described_class.version_error_handler(:my_method) do
-          raise MeiliSearch::ApiError.new(405, 'I came from Meili server', {})
+          raise MeiliSearch::ApiError.new(405, 'I came from Meili server', http_body)
         end
       end.to raise_error(MeiliSearch::ApiError, /that `my_method` call requires/)
     end


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #513 

## What does this PR do?
- Meilisearch::ApiError parses a server's JSON response into its
`@http_body` instance variable which stores a hash.
- When `version_error_handler` propagates `ApiError`, it passes the `@http_body`
hash as http body which causes `ApiError` to attempt to parse it
again as JSON, throwing a `TypeError`.
- This PR makes the `http_body` parameter polymorphic, allowing either a hash or a JSON string to be passed.