### PR TITLE
Drop support for ruby 2 and add ruby 3.2 to CI

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Ruby 2.7
+      - name: Set up Ruby 3.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
       - name: Check release validity
         run: sh .github/scripts/check-release.sh
       - name: Publish to RubyGems

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['3.0', '3.1', '3.2']
     name: integration-tests-against-rc (ruby ${{ matrix.ruby-version }})
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['3.0', '3.1', '3.2']
     name: integration-tests (ruby ${{ matrix.ruby-version }})
     runs-on: ubuntu-22.04
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.0
 
 Style/SymbolArray:
   EnforcedStyle: brackets

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Say goodbye to server deployment and manual updates with [Meilisearch Cloud](htt
 
 ## 🔧 Installation
 
-This package requires Ruby version 2.6.0 or later.
+This package requires Ruby version 3.0.0 or later.
 
 With `gem` in command line:
 ```bash

--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,7 @@
 status = [
-  'integration-tests (ruby 2.6)',
-  'integration-tests (ruby 2.7)',
   'integration-tests (ruby 3.0)',
   'integration-tests (ruby 3.1)',
+  'integration-tests (ruby 3.2)',
   'linter-check'
 ]
 # 1 hour timeout

--- a/lib/meilisearch/utils.rb
+++ b/lib/meilisearch/utils.rb
@@ -2,7 +2,7 @@
 
 module MeiliSearch
   module Utils
-    SNAKE_CASE = /[^a-zA-Z0-9]+(.)/.freeze
+    SNAKE_CASE = /[^a-zA-Z0-9]+(.)/
 
     def self.transform_attributes(body)
       case body

--- a/meilisearch.gemspec
+++ b/meilisearch.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.files       = Dir['{lib}/**/*', 'LICENSE', 'README.md']
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 3.0.0'
   s.add_dependency 'httparty', '>= 0.17.1', '< 0.22.0'
+  s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,7 @@ FINITE_PAGINATED_SEARCH_RESPONSE_KEYS = [
   'totalHits'
 ].freeze
 
-Dir["#{Dir.pwd}/spec/support/**/*.rb"].sort.each { |file| require file }
+Dir["#{Dir.pwd}/spec/support/**/*.rb"].each { |file| require file }
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #514 

## What does this PR do?
- Drops support for ruby `2.6` and `2.7`

I thought I would have the PR ready for whenever we decide to pull the trigger on this. This is not to say that I think we should drop support for these ruby versions right away.