### PR TITLE
Update httparty to v0.22.0

### DIFF
--- a/meilisearch.gemspec
+++ b/meilisearch.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.files       = Dir['{lib}/**/*', 'LICENSE', 'README.md']
 
   s.required_ruby_version = '>= 3.0.0'
-  s.add_dependency 'httparty', '>= 0.17.1', '< 0.22.0'
+  s.add_dependency 'httparty', '>= 0.17.1', '< 0.23.0'
   s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Ruby 3.4.0 will no longer include the CSV gem by default and is throwing a warning because of HTTParty. HTTParty was updated to [v0.22.0](https://github.com/jnunemaker/httparty/releases/tag/v0.22.0) specifically include the CSV gem. This should get rid of the warning

```
warning: /Users/drale2k/.rbenv/versions/3.3.1/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of httparty-0.21.0 to add csv into its gemspec.
````

# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Updates HTTParty to the latest version

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
