### PR TITLE
Remove ruby 3.0 & Upgrade codecov setup

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.1', '3.2', '3.3']
     name: integration-tests-against-rc (ruby ${{ matrix.ruby-version }})
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.1', '3.2', '3.3']
     name: integration-tests (ruby ${{ matrix.ruby-version }})
     runs-on: ubuntu-22.04
     steps:
@@ -34,8 +34,9 @@ jobs:
         run: bundle exec rspec
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: matrix.ruby-version == '3.3'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   linter_check:
     name: linter-check

--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,9 @@ gemspec
 
 group :development, :test do
   gem 'byebug'
-  gem 'codecov'
   gem 'rspec', '~> 3.0'
   gem 'simplecov'
+  gem 'simplecov-cobertura'
 
   # Used only for testing, none of the classes are exposed to the public API.
   gem 'jwt'

--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,8 @@
 status = [
-  'integration-tests (ruby 3.0)',
   'integration-tests (ruby 3.1)',
   'integration-tests (ruby 3.2)',
-  'linter-check'
+  'integration-tests (ruby 3.3)',
+  'linter-check',
 ]
 # 1 hour timeout
 timeout-sec = 3600

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 volumes:
   bundle:
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,11 +22,16 @@
 
 unless ENV.fetch('DISABLE_COVERAGE', false)
   require 'simplecov'
-  require 'codecov'
 
   SimpleCov.start do
     add_filter %r{^/spec/}
-    formatter SimpleCov::Formatter::Codecov if ENV['CI']
+    minimum_coverage 99
+
+    if ENV['CI']
+      require 'simplecov-cobertura'
+
+      formatter SimpleCov::Formatter::CoberturaFormatter
+    end
   end
 end
 


### PR DESCRIPTION
Just a couple of maintenance stuff: 

- remove ruby 3.0 from the CI runs.
- Upload codecov only from the ruby 3.3 execution
- Remove `codecov` gem
- Add `simplecov-cobertura` gem
