### PR TITLE
Fix weird error on global SDK CI from meilisearch/meilisearch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         ruby-version: ['3.1', '3.2', '3.3']
     name: integration-tests (ruby ${{ matrix.ruby-version }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,7 @@ end
 
 require 'meilisearch'
 require 'byebug'
+require 'time'
 
 # Globals for all tests
 URL = format('http://%<host>s:%<port>s',


### PR DESCRIPTION
We use to run a global CI with all the SDKs against the nightly build of meilisearch just to spot any potential error during the development phase of the engine team.

But this time, the error had nothing to do with their implementation; it only involved the ruby CI. The latest run was breaking in a weird way: https://github.com/meilisearch/meilisearch/actions/runs/9941341341/job/27460158817

Somehow, the `time` gem is explicitly required before using some methods like `Time.parse`. I say it is weird because we have the same configuration in this repo, and we don't have that error.

CC: @ellnix @curquiza 