### PR TITLE
Explicitly require json on top of entry file

### DIFF
--- a/lib/meilisearch.rb
+++ b/lib/meilisearch.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 require 'meilisearch/version'
 require 'meilisearch/utils'
 require 'meilisearch/models/task'


### PR DESCRIPTION
# Pull Request

## What does this PR do?

In the context of a pure ruby script with no other gem required, this gem will fail in the most straightforward requests like the `.version` one.

```
/vendor/bundle/ruby/3.0.0/gems/meilisearch-0.28.2/lib/meilisearch/http_request.rb:120:in `http_config': undefined method `to_json' for nil:NilClass (NoMethodError)
        from /vendor/bundle/ruby/3.0.0/gems/meilisearch-0.28.2/lib/meilisearch/http_request.rb:106:in `send_request'
        from /vendor/bundle/ruby/3.0.0/gems/meilisearch-0.28.2/lib/meilisearch/http_request.rb:26:in `http_get'
        from /vendor/bundle/ruby/3.0.0/gems/meilisearch-0.28.2/lib/meilisearch/client.rb:118:in `version'
        from /app/meilisearch/feed_meilisearch.rb:3:in `feed_meilisearch_with'
        from <internal:prelude>:5:in `irb'
        from /app/meilisearch/feed_meilisearch.rb:7:in `feed_meilisearch_with'
        from /app/meilisearch/feed_meilisearch.rb:49:in `load_data_into_meilisearch'
        from meilisearch/app.rb:26:in `<main>'
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
