### PR TITLE
Make index swaps tests more permissive

### DIFF
--- a/spec/meilisearch/client/indexes_spec.rb
+++ b/spec/meilisearch/client/indexes_spec.rb
@@ -268,8 +268,10 @@ RSpec.describe 'Meilisearch::Client - Indexes' do
 
       expect(task.type).to eq('indexSwap')
       task.await
-      expect(task['details']['swaps']).to eq([{ 'indexes' => ['indexA', 'indexB'] },
-                                              { 'indexes' => ['indexC', 'indexD'] }])
+      expect(task['details']['swaps']).to include(
+        include('indexes' => ['indexA', 'indexB']),
+        include('indexes' => ['indexC', 'indexD'])
+      )
     end
   end
 end


### PR DESCRIPTION
Fix [Meilisearch 1.18 tests run](https://github.com/meilisearch/meilisearch/actions/runs/17061126416/job/48368042252)
