### PR TITLE
Assert expected fields presence only in API responses

### DIFF
--- a/spec/meilisearch/index/search/attributes_to_highlight_spec.rb
+++ b/spec/meilisearch/index/search/attributes_to_highlight_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Meilisearch::Index - Search with highlight' do
   it 'does a custom search with highlight' do
     response = index.search('the', attributes_to_highlight: ['title'])
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(4)
     expect(response['hits'].first).to have_key('_formatted')
     expect(response['hits'].first['_formatted']['title']).to eq('<em>The</em> Hobbit')
@@ -15,7 +15,7 @@ RSpec.describe 'Meilisearch::Index - Search with highlight' do
   it 'does a placeholder search with attributes to highlight' do
     response = index.search('', attributes_to_highlight: ['*'])
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(8)
     expect(response['hits'].first).to have_key('_formatted')
   end
@@ -23,7 +23,7 @@ RSpec.describe 'Meilisearch::Index - Search with highlight' do
   it 'does a placeholder search (nil) with attributes to highlight' do
     response = index.search(nil, attributes_to_highlight: ['*'])
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)
     expect(response['hits'].first).to have_key('_formatted')
   end

--- a/spec/meilisearch/index/search/attributes_to_retrieve_spec.rb
+++ b/spec/meilisearch/index/search/attributes_to_retrieve_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Meilisearch::Index - Search with attributes to retrieve' do
   it 'does a custom search with one attributes_to_retrieve' do
     response = index.search('the', attributes_to_retrieve: ['title'])
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(4)
     expect(response['hits'].first).to have_key('title')
     expect(response['hits'].first).not_to have_key('objectId')
@@ -16,7 +16,7 @@ RSpec.describe 'Meilisearch::Index - Search with attributes to retrieve' do
   it 'does a custom search with multiple attributes_to_retrieve' do
     response = index.search('the', attributes_to_retrieve: ['title', 'genre'])
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(4)
     expect(response['hits'].first).to have_key('title')
     expect(response['hits'].first).not_to have_key('objectId')
@@ -26,7 +26,7 @@ RSpec.describe 'Meilisearch::Index - Search with attributes to retrieve' do
   it 'does a custom search with all attributes_to_retrieve' do
     response = index.search('the', attributes_to_retrieve: ['*'])
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(4)
     expect(response['hits'].first).to have_key('objectId')
     expect(response['hits'].first).to have_key('title')
@@ -36,7 +36,7 @@ RSpec.describe 'Meilisearch::Index - Search with attributes to retrieve' do
   it 'does a placeholder search with one attributes_to_retrieve' do
     response = index.search('', attributes_to_retrieve: ['title'])
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)
     expect(response['hits'].first).to have_key('title')
     expect(response['hits'].first).not_to have_key('objectId')
@@ -46,7 +46,7 @@ RSpec.describe 'Meilisearch::Index - Search with attributes to retrieve' do
   it 'does a placeholder search with multiple attributes_to_retrieve' do
     response = index.search('', attributes_to_retrieve: ['title', 'genre'])
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)
     expect(response['hits'].first).to have_key('title')
     expect(response['hits'].first).not_to have_key('objectId')
@@ -56,7 +56,7 @@ RSpec.describe 'Meilisearch::Index - Search with attributes to retrieve' do
   it 'does a placeholder search with all attributes_to_retrieve' do
     response = index.search('', attributes_to_retrieve: ['*'])
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)
     expect(response['hits'].first).to have_key('title')
     expect(response['hits'].first).to have_key('objectId')

--- a/spec/meilisearch/index/search/facets_distribution_spec.rb
+++ b/spec/meilisearch/index/search/facets_distribution_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Meilisearch::Index - Search with facets' do
 
   it 'does a custom search with facets' do
     response = index.search('prinec', facets: ['genre', 'author'])
-    expect(response.keys).to contain_exactly(
+    expect(response.keys).to include(
       *DEFAULT_SEARCH_RESPONSE_KEYS,
       'facetDistribution',
       'facetStats'
@@ -25,7 +25,7 @@ RSpec.describe 'Meilisearch::Index - Search with facets' do
 
   it 'does a placeholder search with facets' do
     response = index.search('', facets: ['genre', 'author'])
-    expect(response.keys).to contain_exactly(
+    expect(response.keys).to include(
       *DEFAULT_SEARCH_RESPONSE_KEYS,
       'facetDistribution',
       'facetStats'
@@ -41,7 +41,7 @@ RSpec.describe 'Meilisearch::Index - Search with facets' do
 
   it 'does a placeholder search with facets on number' do
     response = index.search('', facets: ['year'])
-    expect(response.keys).to contain_exactly(
+    expect(response.keys).to include(
       *DEFAULT_SEARCH_RESPONSE_KEYS,
       'facetDistribution',
       'facetStats'

--- a/spec/meilisearch/index/search/filter_spec.rb
+++ b/spec/meilisearch/index/search/filter_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe 'Meilisearch::Index - Filtered search' do
 
   it 'does a custom search with filter and array syntax' do
     response = index.search('prinec', filter: ['genre = fantasy'])
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['estimatedTotalHits']).to eq(1)
     expect(response['hits'][0]['objectId']).to eq(4)
   end
 
   it 'does a custom search with multiple filter and array syntax' do
     response = index.search('potter', filter: ['genre = fantasy', ['year = 2005']])
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['estimatedTotalHits']).to eq(1)
     expect(response['hits'][0]['objectId']).to eq(4)
   end

--- a/spec/meilisearch/index/search/limit_spec.rb
+++ b/spec/meilisearch/index/search/limit_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Meilisearch::Index - Search with limit' do
   it 'does a custom search with limit' do
     response = index.search('the', limit: 1)
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['limit']).to be(1)
     expect(response['hits'].count).to eq(1)
     expect(response['hits'].first).not_to have_key('_formatted')

--- a/spec/meilisearch/index/search/matches_spec.rb
+++ b/spec/meilisearch/index/search/matches_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Meilisearch::Index - Search with showMatchesPosition' do
   it 'does a custom search with showMatchesPosition' do
     response = index.search('the', show_matches_position: true)
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].first).to have_key('_matchesPosition')
     expect(response['hits'].first['_matchesPosition']).to have_key('title')
   end
@@ -14,7 +14,7 @@ RSpec.describe 'Meilisearch::Index - Search with showMatchesPosition' do
   it 'does a placeholder search with showMatchesPosition' do
     response = index.search('', show_matches_position: true)
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].first).to have_key('_matchesPosition')
   end
 end

--- a/spec/meilisearch/index/search/multi_params_spec.rb
+++ b/spec/meilisearch/index/search/multi_params_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Meilisearch::Index - Multi-paramaters search' do
   it 'does a custom search with attributes_to_retrieve and a limit' do
     response = index.search('the', attributes_to_retrieve: ['title', 'genre'], limit: 2)
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(2)
     expect(response['hits'].first).to have_key('title')
     expect(response['hits'].first).not_to have_key('objectId')
@@ -36,7 +36,7 @@ RSpec.describe 'Meilisearch::Index - Multi-paramaters search' do
   it 'does a custom search with limit and attributes to highlight' do
     response = index.search('the', { limit: 1, attributes_to_highlight: ['*'] })
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(1)
     expect(response['hits'].first).to have_key('_formatted')
   end
@@ -49,7 +49,7 @@ RSpec.describe 'Meilisearch::Index - Multi-paramaters search' do
                               attributes_to_retrieve: ['title'],
                               attributes_to_highlight: ['*']
                             })
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['estimatedTotalHits']).to eq(1)
     expect(response['hits'].first).to have_key('_formatted')
     expect(response['hits'].first).not_to have_key('objectId')
@@ -62,7 +62,7 @@ RSpec.describe 'Meilisearch::Index - Multi-paramaters search' do
     index.update_filterable_attributes(['genre']).await
     response = index.search('prinec', facets: ['genre'], limit: 1)
 
-    expect(response.keys).to contain_exactly(
+    expect(response.keys).to include(
       *DEFAULT_SEARCH_RESPONSE_KEYS,
       'facetDistribution',
       'facetStats'

--- a/spec/meilisearch/index/search/q_spec.rb
+++ b/spec/meilisearch/index/search/q_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Meilisearch::Index - Basic search' do
   it 'does a basic search in index' do
     response = index.search('prince')
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits']).not_to be_empty
     expect(response['hits'].first).not_to have_key('_formatted')
   end
@@ -14,14 +14,14 @@ RSpec.describe 'Meilisearch::Index - Basic search' do
   it 'does a basic search with an empty query' do
     response = index.search('')
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)
   end
 
   it 'does a basic search with a nil query' do
     response = index.search(nil)
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)
     expect(response['hits'].first).not_to have_key('_formatted')
   end
@@ -32,7 +32,7 @@ RSpec.describe 'Meilisearch::Index - Basic search' do
     expect(response).to be_a(Hash)
     expect(response).to have_key('nbHits')
     expect(response['nbHits']).to eq(response['estimatedTotalHits'])
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(documents.count)
     expect(response['hits'].first).not_to have_key('_formatted')
   end
@@ -55,7 +55,7 @@ RSpec.describe 'Meilisearch::Index - Basic search' do
   it 'does a basic search with an integer query' do
     response = index.search(1)
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(3)
     expect(response['hits'].first).not_to have_key('_formatted')
   end
@@ -63,7 +63,7 @@ RSpec.describe 'Meilisearch::Index - Basic search' do
   it 'does a phrase search' do
     response = index.search('coco "harry"')
     expect(response).to be_a(Hash)
-    expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+    expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
     expect(response['hits'].count).to eq(2)
     expect(response['hits'].first['objectId']).to eq(4)
     expect(response['hits'].first).not_to have_key('_formatted')
@@ -72,10 +72,10 @@ RSpec.describe 'Meilisearch::Index - Basic search' do
   context 'with finite pagination params' do
     it 'responds with specialized fields' do
       response = index.search('coco', { page: 2, hits_per_page: 2 })
-      expect(response.keys).to contain_exactly(*FINITE_PAGINATED_SEARCH_RESPONSE_KEYS)
+      expect(response.keys).to include(*FINITE_PAGINATED_SEARCH_RESPONSE_KEYS)
 
       response = index.search('coco', { page: 2, hitsPerPage: 2 })
-      expect(response.keys).to contain_exactly(*FINITE_PAGINATED_SEARCH_RESPONSE_KEYS)
+      expect(response.keys).to include(*FINITE_PAGINATED_SEARCH_RESPONSE_KEYS)
     end
   end
 
@@ -83,35 +83,35 @@ RSpec.describe 'Meilisearch::Index - Basic search' do
     it 'responds with empty attributes_to_search_on' do
       response = index.search('prince', { attributes_to_search_on: [] })
       expect(response).to be_a(Hash)
-      expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+      expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
       expect(response['hits']).to be_empty
     end
 
     it 'responds with nil attributes_to_search_on' do
       response = index.search('prince', { attributes_to_search_on: nil })
       expect(response).to be_a(Hash)
-      expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+      expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
       expect(response['hits']).not_to be_empty
     end
 
     it 'responds with title attributes_to_search_on' do
       response = index.search('prince', { attributes_to_search_on: ['title'] })
       expect(response).to be_a(Hash)
-      expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+      expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
       expect(response['hits']).not_to be_empty
     end
 
     it 'responds with genre attributes_to_search_on' do
       response = index.search('prince', { attributes_to_search_on: ['genry'] })
       expect(response).to be_a(Hash)
-      expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+      expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
       expect(response['hits']).to be_empty
     end
 
     it 'responds with nil attributes_to_search_on and empty query' do
       response = index.search('', { attributes_to_search_on: nil })
       expect(response).to be_a(Hash)
-      expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
+      expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
       expect(response['hits'].count).to eq(documents.count)
     end
   end


### PR DESCRIPTION
## why

Fix SDK tests breaking when running against a newer version of Meilisearch that introduces new fields in API responses.

In this example, adding requestUid to API responses should not break the SDK: https://github.com/meilisearch/meilisearch/actions/runs/18303698439/job/52122364987

## how

Make tests more permissive by replacing assertions with `contain_exactly`:
```ruby
expect(response.keys).to contain_exactly(*DEFAULT_SEARCH_RESPONSE_KEYS)
```

by assertions with `include`:
```ruby
expect(response.keys).to include(*DEFAULT_SEARCH_RESPONSE_KEYS)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions across search functionality to be more flexible and resilient. Tests now verify that required response keys are present while allowing additional keys in responses. This maintains core validation while reducing test brittleness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->