### PR TITLE
Remove bors and use GitHub merge queue

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -28,9 +28,5 @@ template: |
 no-changes-template: 'Changes are coming soon 😎'
 sort-direction: 'ascending'
 replacers:
-  - search: '/(?:and )?@bors(?:\[bot\])?,?/g'
-    replace: ''
   - search: '/(?:and )?@meili-bot,?/g'
-    replace: ''
-  - search: '/(?:and )?@meili-bors(?:\[bot\])?,?/g'
     replace: ''

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,11 +3,9 @@ name: Tests
 on:
   pull_request:
   push:
-    # trying and staging branches are for BORS config
     branches:
-      - trying
-      - staging
       - main
+  merge_group:
 
 jobs:
   integration_tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,18 +128,12 @@ Some notes on GitHub PRs:
 
 - [Convert your PR as a draft](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request) if your changes are a work in progress: no one will review it until you pass your PR as ready for review.<br>
   The draft PR can be very useful if you want to show that you are working on something and make your work visible.
-- The branch related to the PR must be **up-to-date with `main`** before merging. Fortunately, this project [integrates a bot](https://github.com/meilisearch/integration-guides/blob/main/resources/bors.md) to automatically enforce this requirement without the PR author having to do it manually.
 - All PRs must be reviewed and approved by at least one maintainer.
 - The PR title should be accurate and descriptive of the changes. The title of the PR will be indeed automatically added to the next [release changelogs](https://github.com/meilisearch/meilisearch-ruby/releases/).
 
 ## Release Process (for the internal team only)
 
 Meilisearch tools follow the [Semantic Versioning Convention](https://semver.org/).
-
-### Automation to Rebase and Merge the PRs <!-- omit in toc -->
-
-This project integrates a bot that helps us manage pull requests merging.<br>
-_[Read more about this](https://github.com/meilisearch/integration-guides/blob/main/resources/bors.md)._
 
 ### Automated Changelogs <!-- omit in toc -->
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
     <img src="https://codecov.io/gh/meilisearch/meilisearch-ruby/branch/main/graph/badge.svg?token=9J7LRP11IR"/>
   </a>
   <a href="https://github.com/meilisearch/meilisearch-ruby/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-informational" alt="License"></a>
-  <a href="https://ms-bors.herokuapp.com/repositories/6"><img src="https://bors.tech/images/badge_small.svg" alt="Bors enabled"></a>
 </p>
 
 <p align="center">⚡ The Meilisearch API client written for Ruby 💎</p>


### PR DESCRIPTION
Ruleset set up for the usage of GitHub merge queue ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines and README to reflect changes in the development workflow.

* **Chores**
  * Modified CI/CD workflow configuration for test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->