### PR TITLE
Add task documents endpoint

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -515,3 +515,5 @@ distinct_attribute_guide_distinct_parameter_1: |-
   client.index('products').search('white shirt', {
     distinct: 'sku'
   })
+get_task_documents_1: |-
+  client.task_documents(1)

--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -430,6 +430,16 @@ module Meilisearch
       task_endpoint.task(task_uid)
     end
 
+    # Get task's document payload
+    #
+    # Retrieve the document payload that was sent with this task. Only available for document-related tasks that are enqueued or processing.
+    #
+    # @param task_uid [String] uid of the requested task
+    # @return [String] The content of the task update
+    def task_documents(task_uid)
+      task_endpoint.task_documents(task_uid)
+    end
+
     # Wait for a task in a busy loop.
     #
     # Try to avoid using it. Wrapper around {Task#wait_for_task}.

--- a/lib/meilisearch/task.rb
+++ b/lib/meilisearch/task.rb
@@ -19,13 +19,14 @@ module Meilisearch
     def task(task_uid)
       http_get "/tasks/#{task_uid}"
     end
+    alias index_task task
+
+    def task_documents(task_uid)
+      http_get "/tasks/#{task_uid}/documents"
+    end
 
     def index_tasks(index_uid)
       http_get '/tasks', { indexUids: [index_uid].flatten.join(',') }
-    end
-
-    def index_task(task_uid)
-      http_get "/tasks/#{task_uid}"
     end
 
     def cancel_tasks(options)

--- a/spec/meilisearch/client/tasks_spec.rb
+++ b/spec/meilisearch/client/tasks_spec.rb
@@ -91,6 +91,20 @@ RSpec.describe 'Meilisearch::Tasks' do
       )
   end
 
+  it 'gets all the documents from a task' do
+    client.update_experimental_features(getTaskDocumentsRoute: true)
+
+    document_to_insert = { objectId: 123, title: 'Pride and Prejudice', comment: 'A great book' }
+
+    task = index.add_documents(document_to_insert)
+    documents = client.task_documents(task.metadata['uid'])
+
+    expect(documents).to be_a(String)
+    expect(documents).to eq('{"objectId":123,"title":"Pride and Prejudice","comment":"A great book"}')
+
+    client.update_experimental_features(getTaskDocumentsRoute: false)
+  end
+
   describe '#index.wait_for_task' do
     it 'waits for task with default values' do
       task = index.add_documents(documents)


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #685

## What does this PR do?
- Add task documents method
- Set an alias for duplicated method

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds support for the `GET /tasks/{task_id}/documents` endpoint to retrieve task documents, as specified in Meilisearch v1.13.0. It includes the method implementation, tests, and documentation examples.

## Changes

### New functionality
- Added `task_documents(task_uid)` method to `Meilisearch::Client` that retrieves the document payload associated with a task by delegating to `task_endpoint.task_documents(task_uid)`
- Added `task_documents(task_uid)` method to `Meilisearch::Task` that performs a GET request to `/tasks/{task_uid}/documents`

### Refactoring
- Converted `index_task` in `Meilisearch::Task` from a separate method to an alias of the existing `task` method, eliminating duplicate code

### Testing
- Added RSpec test case in `spec/meilisearch/client/tasks_spec.rb` that verifies `client.task_documents` correctly returns documents from a task, including enabling/disabling the experimental `getTaskDocumentsRoute` feature flag

### Documentation
- Added code sample entry `get_task_documents_1` in `.code-samples.meilisearch.yaml` demonstrating usage via `client.task_documents(1)`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meilisearch/meilisearch-ruby/pull/698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->