### PR TITLE
feat(stats): add show_internal_database_sizes and size_format params for Meilisearch v1.44

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -240,9 +240,9 @@ reset_displayed_attributes_1: |-
 compact_index_1: |-
   client.index('INDEX_UID').compact
 get_index_stats_1: |-
-  client.index('movies').stats
+  client.index('movies').stats(show_internal_database_sizes: true, size_format: 'human')
 get_indexes_stats_1: |-
-  client.stats
+  client.stats(show_internal_database_sizes: true, size_format: 'human')
 get_health_1: |-
   client.health
 get_version_1: |-

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Metrics/AbcSize:
 # Offense count: 4
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 541
+  Max: 542
 
 # Offense count: 4
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.

--- a/lib/meilisearch/client.rb
+++ b/lib/meilisearch/client.rb
@@ -305,11 +305,20 @@ module Meilisearch
 
     # Get stats of all indexes in instance.
     #
+    # @param show_internal_database_sizes [Boolean] When +true+, each index stat object includes an
+    #   +internalDatabaseSizes+ map. The keys in this map are subject to change.
+    # @param size_format [String, nil] Controls how size fields are returned.
+    #   Use <tt>'human'</tt> for human-readable strings (e.g. <tt>"2.3 MiB"</tt>),
+    #   or <tt>'raw'</tt> (default) for numeric byte counts.
     # @see Index#stats
     # @see https://www.meilisearch.com/docs/reference/api/stats#get-stats-of-all-indexes Meilisearch API reference
     # @return [Hash{String => Object}] see {stats object}[https://www.meilisearch.com/docs/reference/api/stats#stats-object]
-    def stats
-      http_get '/stats'
+    def stats(show_internal_database_sizes: nil, size_format: nil)
+      params = {
+        showInternalDatabaseSizes: show_internal_database_sizes,
+        sizeFormat: size_format
+      }.compact
+      http_get '/stats', params
     end
 
     ### DUMPS

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -684,11 +684,8 @@ module Meilisearch
     # @return [Hash{String => Object}]
     # @see https://www.meilisearch.com/docs/reference/api/stats#get-stats-of-an-index  Meilisearch API Reference
     def stats(show_internal_database_sizes: nil, size_format: nil)
-      params = {
-        showInternalDatabaseSizes: show_internal_database_sizes,
-        sizeFormat: size_format
-      }.compact
-      http_get "/indexes/#{@uid}/stats", params
+      params = { showInternalDatabaseSizes: show_internal_database_sizes, sizeFormat: size_format }
+      http_get "/indexes/#{@uid}/stats", params.compact
     end
 
     # Get the number of documents in the index.

--- a/lib/meilisearch/index.rb
+++ b/lib/meilisearch/index.rb
@@ -675,10 +675,20 @@ module Meilisearch
 
     # Get stats of this index.
     #
+    # @param show_internal_database_sizes [Boolean] When +true+, the response includes an
+    #   +internalDatabaseSizes+ map of internal database names to their sizes.
+    #   The keys in this map are subject to change.
+    # @param size_format [String, nil] Controls how size fields are returned.
+    #   Use <tt>'human'</tt> for human-readable strings (e.g. <tt>"2.3 MiB"</tt>),
+    #   or <tt>'raw'</tt> (default) for numeric byte counts.
     # @return [Hash{String => Object}]
     # @see https://www.meilisearch.com/docs/reference/api/stats#get-stats-of-an-index  Meilisearch API Reference
-    def stats
-      http_get "/indexes/#{@uid}/stats"
+    def stats(show_internal_database_sizes: nil, size_format: nil)
+      params = {
+        showInternalDatabaseSizes: show_internal_database_sizes,
+        sizeFormat: size_format
+      }.compact
+      http_get "/indexes/#{@uid}/stats", params
     end
 
     # Get the number of documents in the index.

--- a/spec/meilisearch/client/stats_spec.rb
+++ b/spec/meilisearch/client/stats_spec.rb
@@ -13,4 +13,20 @@ RSpec.describe 'Meilisearch::Client - Stats' do
     response = client.stats
     expect(response).to have_key('databaseSize')
   end
+
+  it 'gets stats with human-readable size format' do
+    response = client.stats(size_format: 'human')
+    expect(response).to have_key('databaseSize')
+    expect(response['databaseSize']).to be_a(String)
+  end
+
+  it 'gets stats with internal database sizes' do
+    client.create_index('books').await
+    response = client.stats(show_internal_database_sizes: true)
+
+    expect(response).to have_key('indexes')
+    response['indexes'].each_value do |index_stats|
+      expect(index_stats).to have_key('internalDatabaseSizes')
+    end
+  end
 end

--- a/spec/meilisearch/index/stats_spec.rb
+++ b/spec/meilisearch/index/stats_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe 'Meilisearch::Index - Stats' do
     expect(response).not_to be_empty
   end
 
+  it 'returns stats with human-readable size format' do
+    response = index.stats(size_format: 'human')
+    expect(response).to have_key('rawDocumentDbSize')
+    expect(response['rawDocumentDbSize']).to be_a(String)
+  end
+
+  it 'returns stats with internal database sizes' do
+    response = index.stats(show_internal_database_sizes: true)
+    expect(response).to have_key('internalDatabaseSizes')
+    expect(response['internalDatabaseSizes']).to be_a(Hash)
+  end
+
   it 'gets the number of documents' do
     response = index.number_of_documents
     expect(response).to eq(documents.count)


### PR DESCRIPTION
Closes #697.

Adds support for the two new query parameters introduced in [Meilisearch v1.44.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.44.0) for the stats endpoints.

## Changes

**`lib/meilisearch/index.rb`** — `stats` now accepts optional keyword args:
- `show_internal_database_sizes:` — when `true`, the response includes `internalDatabaseSizes` (keys subject to change)
- `size_format:` — `'human'` returns sizes as strings like `"2.3 MiB"`, `'raw'` (default) returns byte counts

**`lib/meilisearch/client.rb`** — same optional keyword args on `Client#stats`

**`.code-samples.meilisearch.yaml`** — updated `get_index_stats_1` and `get_indexes_stats_1`

Both methods build the params hash and call `.compact` to drop `nil` values, so existing callers with no arguments continue to work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds support for two new optional query parameters to the stats endpoints, aligning with Meilisearch v1.44.0:

- `show_internal_database_sizes` (boolean): when true, responses include an `internalDatabaseSizes` mapping (keys subject to change; should not be strongly typed).
- `size_format` (string: `'human'` or `'raw'`): controls size formatting — `'human'` returns human-readable strings (e.g., "2.3 MiB"); `'raw'` returns numeric byte counts (default).

## Changes

- lib/meilisearch/index.rb: `Index#stats` now accepts keyword args `show_internal_database_sizes: nil, size_format: nil`; builds a params hash with camel-cased keys (`showInternalDatabaseSizes`, `sizeFormat`), compacts nils, and passes them to the `/indexes/:uid/stats` HTTP GET.
- lib/meilisearch/client.rb: `Client#stats` updated similarly to accept the same keyword args and pass them as query params to `GET /stats`.
- .code-samples.meilisearch.yaml: Updated examples `get_index_stats_1` and `get_indexes_stats_1` to call the new methods with `show_internal_database_sizes: true, size_format: 'human'`.
- spec/meilisearch/client/stats_spec.rb and spec/meilisearch/index/stats_spec.rb: Added tests covering both new parameters:
  - Verify `size_format: 'human'` returns size fields as Strings.
  - Verify `show_internal_database_sizes: true` includes `internalDatabaseSizes` in responses.
- .rubocop_todo.yml: Incremented `Metrics/ClassLength` Max from 541 to 542 to address a RuboCop offense introduced by the change (class length baseline bump).

All changes preserve backward compatibility — omitting the new args leaves behavior unchanged.

## Related issue

Closes `#697`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->